### PR TITLE
Add issue templates and reporting guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug report
+description: Report a reproducible problem in the MijnTed integration
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include clear reproduction steps and relevant logs.
+        Remove secrets from logs and screenshots (client ID, tokens, email, password).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the problem.
+      placeholder: The config flow fails with a 500 error when opening options for an already registered device.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide exact steps so we can reproduce the issue.
+      placeholder: |
+        1. Go to Settings > Devices & Services
+        2. Open MijnTed integration options
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The options flow should open and show configuration fields.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: A 500 Internal Server Error dialog is shown.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste the full warning/traceback block.
+      render: text
+      placeholder: |
+        Logger:
+        Source:
+        Traceback:
+    validations:
+      required: true
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: 2026.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: MijnTed integration version
+      description: See custom_components/mijnted/manifest.json
+      placeholder: 1.0.22
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      placeholder: 3.13.x
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed or masked secrets from logs and screenshots.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting guide
+    url: https://github.com/codezorz/home-assistant-mijnted/blob/main/README.md#troubleshooting
+    about: Check common setup and runtime issues before opening a bug.
+  - name: Issue reporting guide
+    url: https://github.com/codezorz/home-assistant-mijnted/blob/main/doc/ISSUE_REPORTING.md
+    about: See what to include in a complete and actionable issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest an improvement or new capability
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the outcome you want and why it matters.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What pain point are you solving?
+      placeholder: I cannot compare current month usage against a configurable baseline in dashboards.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you want the integration to do.
+      placeholder: Add a sensor that exposes a configurable baseline usage value and variance.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: I currently calculate this with templates, but it is hard to maintain.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include screenshots, examples, or links if relevant.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,50 @@
+name: Question
+description: Ask for clarification about setup or behavior
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for support-style questions. For reproducible defects, use the bug report template.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      placeholder: How should I interpret the "last update" sensor when data is delayed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you already tried
+      placeholder: I checked README troubleshooting and enabled debug logs.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: 2026.2.0
+    validations:
+      required: false
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: MijnTed integration version
+      placeholder: 1.0.22
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ logger:
     custom_components.mijnted: debug
 ```
 
+## Reporting issues
+
+When opening a GitHub issue, include reproducible steps, expected vs actual behavior, logs, and environment details.
+
+- See `doc/ISSUE_REPORTING.md` for a full checklist and copy/paste bug report template.
+- Use the default GitHub issue forms (`Bug report`, `Feature request`, `Question`) to start with the right structure.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
@@ -160,4 +167,3 @@ The integration uses the following dependencies:
 - `PyJWT` - For JWT token decoding
 - `pkce` - For PKCE code generation in OAuth flow
 - `requests` - For synchronous HTTP requests during authentication
-

--- a/doc/ISSUE_REPORTING.md
+++ b/doc/ISSUE_REPORTING.md
@@ -1,0 +1,73 @@
+# Reporting Issues
+
+Use this guide when opening a GitHub issue for this integration.
+
+GitHub issue forms are available by default:
+- `Bug report`
+- `Feature request`
+- `Question`
+
+## Before opening an issue
+
+1. Search existing issues first to avoid duplicates.
+2. Confirm you are running the latest release of the integration.
+3. Reproduce the problem at least once with debug logging enabled.
+4. Remove secrets from logs and screenshots (client ID, tokens, email, passwords).
+
+## Choose the right issue type
+
+- Bug: Something that worked before or should work but does not.
+- Feature request: New behavior or improvement.
+- Question: Clarification about setup or behavior.
+
+## What to include in a bug report
+
+1. Short summary
+2. Exact steps to reproduce
+3. Expected behavior
+4. Actual behavior
+5. Relevant logs (full stack trace or warning block)
+6. Environment details:
+   - Home Assistant version
+   - Integration version (`custom_components/mijnted/manifest.json`)
+   - Python version (if available)
+7. Screenshots (if UI-related)
+
+## Bug report template
+
+Copy this into a new issue and fill it in:
+
+````md
+## Summary
+<!-- One sentence describing the problem -->
+
+## Reproduction
+1.
+2.
+3.
+
+## Expected behavior
+<!-- What should happen -->
+
+## Actual behavior
+<!-- What happens instead -->
+
+## Logs
+```text
+<!-- Paste full warning/error block here -->
+```
+
+## Environment
+- Home Assistant version:
+- MijnTed integration version:
+- Python version:
+
+## Additional context
+<!-- Screenshots, related issues, workarounds -->
+````
+
+## Suggested labels
+
+- `bug` for failures and regressions
+- `enhancement` for feature requests
+- `question` for support-style issues


### PR DESCRIPTION
## Summary
Add standardized GitHub issue templates and a repository issue-reporting guide.

## Changes
- Add `.github/ISSUE_TEMPLATE/bug_report.yml` with required repro/log/environment fields and default `bug` label
- Add `.github/ISSUE_TEMPLATE/feature_request.yml` with default `enhancement` label
- Add `.github/ISSUE_TEMPLATE/question.yml` with default `question` label
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and add contact links
- Add `doc/ISSUE_REPORTING.md` with reporting checklist and copy/paste bug template
- Update `README.md` to point to the new reporting guide and default issue forms

## Notes
- No integration runtime changes
- No version bump (as requested)
