### PR TITLE
Adopt has_entity_name, fix frozen monthly statistics and stale completion readings

### DIFF
--- a/custom_components/mijnted/__init__.py
+++ b/custom_components/mijnted/__init__.py
@@ -824,20 +824,51 @@ async def _lock_current_month_starts_when_previous_complete(
         )
 
     prev_devices = MijnTedSensor._get_devices_from_cache_entry(prev_month_data)
-    prev_end_readings = _extract_end_values_from_devices(prev_devices)
+    cached_end_readings = _extract_end_values_from_devices(prev_devices)
+
+    prev_last_day = DateUtil.get_last_day_of_month(prev_month, prev_year)
+    try:
+        prev_anchor = await api.get_device_statuses_for_date(prev_last_day)
+        prev_end_readings = DataUtil.extract_device_readings_map(prev_anchor)
+    except Exception as err:
+        _LOGGER.warning(
+            "Failed to fetch previous month end readings for start lock: %s",
+            err,
+            extra={"error_type": type(err).__name__},
+            exc_info=True,
+        )
+        prev_end_readings = cached_end_readings
+
     if not prev_end_readings:
-        try:
-            prev_last_day = DateUtil.get_last_day_of_month(prev_month, prev_year)
-            prev_anchor = await api.get_device_statuses_for_date(prev_last_day)
-            prev_end_readings = DataUtil.extract_device_readings_map(prev_anchor)
-        except Exception as err:
-            _LOGGER.warning(
-                "Failed to fetch previous month end readings for start lock: %s",
-                err,
-                extra={"error_type": type(err).__name__},
-                exc_info=True,
+        return modified
+
+    if prev_end_readings != cached_end_readings and isinstance(prev_month_data, MonthCacheEntry):
+        prev_start_readings = _extract_start_values_from_devices(prev_devices)
+        prev_recalculated = DataUtil.calculate_per_device_usage(prev_start_readings, prev_end_readings)
+        if prev_recalculated:
+            prev_start_total = sum(prev_start_readings.values()) if prev_start_readings else None
+            prev_end_total = sum(prev_end_readings.values())
+            corrected_total = _calculate_total_usage_from_start_end(
+                prev_start_total, prev_end_total, prev_month
             )
-            return modified
+            old_total = prev_month_data.total_usage
+            monthly_history_cache[prev_month_key] = _build_updated_month_cache_entry(
+                prev_month_data,
+                total_usage=corrected_total,
+                average_usage=prev_month_data.average_usage,
+                devices=_convert_device_dicts_to_readings(prev_recalculated),
+                finalized=prev_month_data.finalized,
+                state=prev_month_data.state,
+                start_locked=prev_month_data.start_locked,
+            )
+            prev_month_data = monthly_history_cache[prev_month_key]
+            modified = True
+            _LOGGER.info(
+                "Corrected previous month %s with anchor readings (total_usage: %s -> %s).",
+                prev_month_key,
+                old_total,
+                corrected_total,
+            )
 
     current_month_cache = _normalize_cache_entry_state(monthly_history_cache.get(current_month_key))
     if isinstance(current_month_cache, MonthCacheEntry):

--- a/custom_components/mijnted/button.py
+++ b/custom_components/mijnted/button.py
@@ -4,7 +4,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_NAME, DEFAULT_NAME, DOMAIN
 from .sensors import MijnTedResetStatisticsButton
 
 
@@ -21,9 +21,10 @@ async def async_setup_entry(
         async_add_entities: Callback to add entities
     """
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    config_name = entry.data.get(CONF_NAME, DEFAULT_NAME)
     
     buttons: List[ButtonEntity] = [
-        MijnTedResetStatisticsButton(coordinator, hass=hass, entry_id=entry.entry_id)
+        MijnTedResetStatisticsButton(coordinator, hass=hass, entry_id=entry.entry_id, config_name=config_name)
     ]
     
     async_add_entities(buttons, True)

--- a/custom_components/mijnted/config_flow.py
+++ b/custom_components/mijnted/config_flow.py
@@ -12,9 +12,11 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
+    CONF_NAME,
     CONF_PASSWORD,
     CONF_POLLING_INTERVAL,
     CONF_USERNAME,
+    DEFAULT_NAME,
     DEFAULT_POLLING_INTERVAL,
     DOMAIN,
     MAX_POLLING_INTERVAL,
@@ -94,6 +96,7 @@ class MijnTedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_CLIENT_ID): str,
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
+                vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
                 vol.Optional(
                     CONF_POLLING_INTERVAL,
                     default=DEFAULT_POLLING_INTERVAL.total_seconds()
@@ -120,7 +123,7 @@ class MijnTedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._ensure_polling_interval_default(user_input)
                 await self._validate_input(user_input)
                 return self.async_create_entry(
-                    title="MijnTed",
+                    title=user_input.get(CONF_NAME, DEFAULT_NAME),
                     data=user_input
                 )
             except InvalidAuth:
@@ -272,8 +275,10 @@ class MijnTedOptionsFlowHandler(config_entries.OptionsFlow):
         """
         if user_input is not None:
             updated_data = {**self.config_entry.data, **user_input}
+            new_title = updated_data.get(CONF_NAME, DEFAULT_NAME)
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
+                title=new_title,
                 data=updated_data,
             )
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
@@ -283,6 +288,10 @@ class MijnTedOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
+                    vol.Optional(
+                        CONF_NAME,
+                        default=self.config_entry.data.get(CONF_NAME, DEFAULT_NAME),
+                    ): str,
                     vol.Optional(
                         CONF_POLLING_INTERVAL,
                         default=self.config_entry.data.get(

--- a/custom_components/mijnted/const.py
+++ b/custom_components/mijnted/const.py
@@ -57,6 +57,8 @@ TIMESTAMP_FORMAT_ISO_Z = "%Y-%m-%dT%H:%M:%SZ"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_POLLING_INTERVAL = "polling_interval"
+CONF_NAME = "name"
+DEFAULT_NAME = "MijnTed"
 
 # Azure B2C authentication constants
 AUTH_TENANT_NAME = "mytedprod"

--- a/custom_components/mijnted/manifest.json
+++ b/custom_components/mijnted/manifest.json
@@ -7,5 +7,5 @@
     "iot_class": "cloud_polling",
     "config_flow": true,
     "requirements": ["aiohttp", "PyJWT", "pkce", "requests"],
-    "version": "1.0.25"
+    "version": "1.1.0"
 }

--- a/custom_components/mijnted/sensor.py
+++ b/custom_components/mijnted/sensor.py
@@ -4,7 +4,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_NAME, DEFAULT_NAME, DOMAIN
 from .sensors import (
     MijnTedMonthlyUsageSensor,
     MijnTedLastUpdateSensor,
@@ -35,20 +35,21 @@ async def async_setup_entry(
         async_add_entities: Callback to add entities
     """
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    config_name = entry.data.get(CONF_NAME, DEFAULT_NAME)
     
     sensors: List[SensorEntity] = [
-        MijnTedMonthlyUsageSensor(coordinator),
-        MijnTedLastUpdateSensor(coordinator),
-        MijnTedTotalUsageSensor(coordinator),
-        MijnTedActiveModelSensor(coordinator),
-        MijnTedDeliveryTypesSensor(coordinator),
-        MijnTedResidentialUnitDetailSensor(coordinator),
-        MijnTedUnitOfMeasuresSensor(coordinator),
-        MijnTedLastSuccessfulSyncSensor(coordinator),
-        MijnTedAverageMonthlyUsageSensor(coordinator),
-        MijnTedLastYearAverageMonthlyUsageSensor(coordinator),
-        MijnTedLastYearMonthlyUsageSensor(coordinator),
-        MijnTedLatestAvailableInsightSensor(coordinator)
+        MijnTedMonthlyUsageSensor(coordinator, config_name=config_name),
+        MijnTedLastUpdateSensor(coordinator, config_name=config_name),
+        MijnTedTotalUsageSensor(coordinator, config_name=config_name),
+        MijnTedActiveModelSensor(coordinator, config_name=config_name),
+        MijnTedDeliveryTypesSensor(coordinator, config_name=config_name),
+        MijnTedResidentialUnitDetailSensor(coordinator, config_name=config_name),
+        MijnTedUnitOfMeasuresSensor(coordinator, config_name=config_name),
+        MijnTedLastSuccessfulSyncSensor(coordinator, config_name=config_name),
+        MijnTedAverageMonthlyUsageSensor(coordinator, config_name=config_name),
+        MijnTedLastYearAverageMonthlyUsageSensor(coordinator, config_name=config_name),
+        MijnTedLastYearMonthlyUsageSensor(coordinator, config_name=config_name),
+        MijnTedLatestAvailableInsightSensor(coordinator, config_name=config_name),
     ]
     
     filter_status = coordinator.data.get("filter_status", [])
@@ -61,6 +62,6 @@ async def async_setup_entry(
                     device_id = str(device_number)
                     if device_id not in seen_devices:
                         seen_devices.add(device_id)
-                        sensors.append(MijnTedDeviceSensor(coordinator, device_id))
+                        sensors.append(MijnTedDeviceSensor(coordinator, device_id, config_name=config_name))
     
     async_add_entities(sensors, True)

--- a/custom_components/mijnted/sensors/base.py
+++ b/custom_components/mijnted/sensors/base.py
@@ -350,6 +350,10 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
         if month_key in self._get_statistics_reinject_months():
             return False
         
+        now = datetime.now()
+        if start_time.month == now.month and start_time.year == now.year:
+            return False
+        
         data = self.coordinator.data if hasattr(self, 'coordinator') else None
         if not data:
             return False

--- a/custom_components/mijnted/sensors/base.py
+++ b/custom_components/mijnted/sensors/base.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpda
 from ..const import (
     API_DATE_FORMAT,
     CALCULATION_AVERAGE_PER_DAY_DECIMAL_PLACES,
+    DEFAULT_NAME,
     DEFAULT_START_VALUE,
     DOMAIN,
     UNIT_MIJNTED,
@@ -57,60 +58,44 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
     Args:
         coordinator: DataUpdateCoordinator providing MijnTed API data.
         sensor_type: Type identifier for the sensor (e.g. "last_update", "device_0").
-        name: Display name for the sensor entity.
+        name: Display name for the sensor entity (without device prefix).
+        config_name: User-configured device name (e.g. "MijnTed", "Home").
     """
+
+    _attr_has_entity_name = True
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], sensor_type: str, name: str) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], sensor_type: str, name: str, config_name: str = DEFAULT_NAME) -> None:
         """Initialize the sensor.
         
         Args:
             coordinator: Data update coordinator
             sensor_type: Type identifier for the sensor
             name: Display name for the sensor
+            config_name: User-configured device name
         """
         super().__init__(coordinator)
         self.sensor_type = sensor_type
         self._name = name
+        self._config_name = config_name
         self._attr_unique_id = f"{DOMAIN}_{sensor_type.lower()}"
         self._last_known_value = None
 
     @staticmethod
-    def _build_device_name_from_address(residential_unit_detail: Dict[str, Any]) -> str:
-        """Build device name from address fields, falling back to 'MijnTed'."""
-        street = residential_unit_detail.get("street", "")
-        appartment_no = residential_unit_detail.get("appartmentNo", "")
-        zip_code = residential_unit_detail.get("zipCode", "")
-
-        address_parts = []
-        if street:
-            address_parts.append(f"{street} {appartment_no}" if appartment_no else street)
-        elif appartment_no:
-            address_parts.append(appartment_no)
-        if zip_code:
-            address_parts.append(zip_code)
-
-        return f"MijnTed - {', '.join(address_parts)}" if address_parts else "MijnTed"
-
-    @staticmethod
-    def _build_device_info(data: Optional[Dict[str, Any]]) -> DeviceInfo:
+    def _build_device_info(data: Optional[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> DeviceInfo:
         """Build device information from coordinator data."""
         if not data:
             return DeviceInfo(
                 identifiers={(DOMAIN, "unknown")},
-                name="MijnTed",
+                name=config_name,
                 manufacturer="MijnTed",
                 model="Unknown",
             )
 
         residential_unit = data.get("residential_unit", "unknown")
-        residential_unit_detail = data.get("residential_unit_detail", {})
-        device_name = "MijnTed"
-        if isinstance(residential_unit_detail, dict):
-            device_name = MijnTedSensor._build_device_name_from_address(residential_unit_detail)
 
         return DeviceInfo(
             identifiers={(DOMAIN, residential_unit)},
-            name=device_name,
+            name=config_name,
             manufacturer="MijnTed",
             model=data.get("active_model", "Unknown"),
         )
@@ -122,16 +107,16 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
         Returns:
             DeviceInfo object with device identifiers and details
         """
-        return self._build_device_info(self.coordinator.data)
+        return self._build_device_info(self.coordinator.data, self._config_name)
 
     @property
     def name(self) -> str:
         """Return the name of the sensor.
         
         Returns:
-            Formatted sensor name with "MijnTed" prefix
+            Capitalized sensor name (device prefix handled by has_entity_name)
         """
-        return f"MijnTed {self._name}"
+        return self._name.capitalize()
     
     @property
     def available(self) -> bool:

--- a/custom_components/mijnted/sensors/button.py
+++ b/custom_components/mijnted/sensors/button.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.helpers.storage import Store
-from ..const import DOMAIN
+from ..const import DEFAULT_NAME, DOMAIN
 from .base import MijnTedSensor
 from .models import StatisticsTracking
 
@@ -25,13 +25,17 @@ class MijnTedResetStatisticsButton(CoordinatorEntity, ButtonEntity):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
         hass: Home Assistant instance (optional; will try to get from coordinator).
         entry_id: Config entry ID (optional; will try to find from coordinator).
+        config_name: User-configured device name (e.g. "MijnTed", "Home").
     """
+
+    _attr_has_entity_name = True
     
     def __init__(
         self, 
         coordinator: DataUpdateCoordinator[Dict[str, Any]],
         hass: Optional[HomeAssistant] = None,
-        entry_id: Optional[str] = None
+        entry_id: Optional[str] = None,
+        config_name: str = DEFAULT_NAME,
     ) -> None:
         """Initialize the reset statistics button.
         
@@ -39,12 +43,14 @@ class MijnTedResetStatisticsButton(CoordinatorEntity, ButtonEntity):
             coordinator: Data update coordinator
             hass: Home Assistant instance (optional, will try to get from coordinator)
             entry_id: Config entry ID (optional, will try to find from coordinator)
+            config_name: User-configured device name
         """
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}_reset_statistics"
-        self._attr_name = "MijnTed reset statistics"
+        self._attr_name = "Reset statistics"
         self._attr_icon = "mdi:refresh"
         self._attr_entity_category = EntityCategory.CONFIG
+        self._config_name = config_name
         self._hass = hass
         self._entry_id = entry_id
     
@@ -55,7 +61,7 @@ class MijnTedResetStatisticsButton(CoordinatorEntity, ButtonEntity):
         Returns:
             DeviceInfo object with device identifiers and details
         """
-        return MijnTedSensor._build_device_info(self.coordinator.data)
+        return MijnTedSensor._build_device_info(self.coordinator.data, self._config_name)
     
     async def async_press(self) -> None:
         """Handle the button press - reset statistics tracking and clear persisted storage.

--- a/custom_components/mijnted/sensors/device.py
+++ b/custom_components/mijnted/sensors/device.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .base import MijnTedSensor
-from ..const import DOMAIN, UNIT_MIJNTED
+from ..const import DEFAULT_NAME, DOMAIN, UNIT_MIJNTED
 from ..utils import TranslationUtil
 
 
@@ -15,17 +15,19 @@ class MijnTedDeviceSensor(MijnTedSensor):
         device_number: Zero-based index or identifier of the device in the filter_status list.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], device_number: str) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], device_number: str, config_name: str = DEFAULT_NAME) -> None:
         """Initialize the device sensor.
         
         Args:
             coordinator: Data update coordinator
             device_number: Device number identifier
+            config_name: User-configured device name
         """
         super().__init__(
             coordinator,
             f"device_{device_number}",
-            f"device {device_number}"
+            f"device {device_number}",
+            config_name=config_name,
         )
         self.device_number = device_number
         self._attr_icon = "mdi:radiator"
@@ -64,15 +66,15 @@ class MijnTedDeviceSensor(MijnTedSensor):
         """Return the name of the sensor.
         
         Returns:
-            Formatted sensor name with room name if available, otherwise device number
+            Sensor name with room name if available, otherwise device number
         """
         device_data = self._device_data
         if device_data and device_data.get("room"):
             room_code = device_data['room']
             hass = getattr(self.coordinator, 'hass', None)
             room_name = TranslationUtil.translate_room_code(room_code, hass)
-            return f"MijnTed device {room_name}"
-        return f"MijnTed device {self.device_number}"
+            return f"Device {room_name}"
+        return f"Device {self.device_number}"
 
     @property
     def state(self) -> Any:

--- a/custom_components/mijnted/sensors/diagnostics.py
+++ b/custom_components/mijnted/sensors/diagnostics.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .base import MijnTedSensor
 from .models import StatisticsTracking
 from ..utils import TimestampUtil, ListUtil, DataUtil, DateUtil
-from ..const import CALCULATION_YEAR_MONTH_SORT_MULTIPLIER
+from ..const import CALCULATION_YEAR_MONTH_SORT_MULTIPLIER, DEFAULT_NAME
 
 
 class MijnTedLastUpdateSensor(MijnTedSensor):
@@ -17,13 +17,14 @@ class MijnTedLastUpdateSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the last update sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "last_update", "last update")
+        super().__init__(coordinator, "last_update", "last update", config_name=config_name)
         self._attr_icon = "mdi:clock-outline"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -59,13 +60,14 @@ class MijnTedActiveModelSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the active model sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "active_model", "active model")
+        super().__init__(coordinator, "active_model", "active model", config_name=config_name)
         self._attr_icon = "mdi:tag"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -91,13 +93,14 @@ class MijnTedDeliveryTypesSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the delivery types sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "delivery_types", "delivery type")
+        super().__init__(coordinator, "delivery_types", "delivery type", config_name=config_name)
         self._attr_icon = "mdi:package-variant"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -127,13 +130,14 @@ class MijnTedResidentialUnitDetailSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the residential unit detail sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "residential_unit_detail", "residential unit")
+        super().__init__(coordinator, "residential_unit_detail", "residential unit", config_name=config_name)
         self._attr_icon = "mdi:home"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -171,13 +175,14 @@ class MijnTedUnitOfMeasuresSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the unit of measures sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "unit_of_measures", "unit of measures")
+        super().__init__(coordinator, "unit_of_measures", "unit of measures", config_name=config_name)
         self._attr_icon = "mdi:ruler"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -227,13 +232,14 @@ class MijnTedLastSuccessfulSyncSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the last successful sync sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "last_successful_sync", "last successful sync")
+        super().__init__(coordinator, "last_successful_sync", "last successful sync", config_name=config_name)
         self._attr_icon = "mdi:clock-check"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -258,13 +264,14 @@ class MijnTedLatestAvailableInsightSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the latest available insight sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "latest_available_insight", "latest available insight")
+        super().__init__(coordinator, "latest_available_insight", "latest available insight", config_name=config_name)
         self._attr_icon = "mdi:calendar-month"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_native_unit_of_measurement = None

--- a/custom_components/mijnted/sensors/usage.py
+++ b/custom_components/mijnted/sensors/usage.py
@@ -4,7 +4,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.components.recorder.models import StatisticData, StatisticMeanType
 from .base import MijnTedSensor
 from ..utils import DataUtil
-from ..const import UNIT_MIJNTED, DEFAULT_START_VALUE
+from ..const import DEFAULT_NAME, UNIT_MIJNTED, DEFAULT_START_VALUE
 from .models import CurrentData
 
 
@@ -17,13 +17,14 @@ class MijnTedMonthlyUsageSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the monthly usage sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "monthly_usage", "monthly usage")
+        super().__init__(coordinator, "monthly_usage", "monthly usage", config_name=config_name)
         self._attr_icon = "mdi:lightning-bolt"
         self._attr_suggested_display_precision = 0
 
@@ -122,13 +123,14 @@ class MijnTedLastYearMonthlyUsageSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the last year monthly usage sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "last_year_monthly_usage", "last year monthly usage")
+        super().__init__(coordinator, "last_year_monthly_usage", "last year monthly usage", config_name=config_name)
         self._attr_icon = "mdi:lightning-bolt"
         self._attr_suggested_display_precision = 0
 
@@ -192,13 +194,14 @@ class MijnTedAverageMonthlyUsageSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the average monthly usage sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "average_monthly_usage", "average monthly usage")
+        super().__init__(coordinator, "average_monthly_usage", "average monthly usage", config_name=config_name)
         self._attr_icon = "mdi:chart-line"
         self._attr_suggested_display_precision = 0
 
@@ -273,13 +276,14 @@ class MijnTedLastYearAverageMonthlyUsageSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the last year average monthly usage sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "last_year_average_monthly_usage", "last year average monthly usage")
+        super().__init__(coordinator, "last_year_average_monthly_usage", "last year average monthly usage", config_name=config_name)
         self._attr_icon = "mdi:chart-line-variant"
         self._attr_suggested_display_precision = 0
 
@@ -343,13 +347,14 @@ class MijnTedTotalUsageSensor(MijnTedSensor):
         coordinator: DataUpdateCoordinator providing MijnTed API data.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]]) -> None:
+    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], config_name: str = DEFAULT_NAME) -> None:
         """Initialize the total usage sensor.
         
         Args:
             coordinator: Data update coordinator
+            config_name: User-configured device name
         """
-        super().__init__(coordinator, "total_usage", "total usage")
+        super().__init__(coordinator, "total_usage", "total usage", config_name=config_name)
         self._attr_icon = "mdi:lightning-bolt"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self._attr_suggested_display_precision = 0

--- a/custom_components/mijnted/translations/en.json
+++ b/custom_components/mijnted/translations/en.json
@@ -7,6 +7,7 @@
           "username": "MijnTed account username",
           "password": "MijnTed account password",
           "client_id": "MijnTed account client-id",
+          "name": "Device name (e.g. MijnTed, Home, Office)",
           "polling_interval": "Polling interval (seconds)"
         },
         "description": "How often to poll the API for updates. Default: 3600 seconds (1 hour). Range: 900-86400 seconds (15 minutes to 24 hours)."
@@ -43,6 +44,7 @@
     "step": {
       "mijnted_options": {
         "data": {
+          "name": "Device name (e.g. MijnTed, Home, Office)",
           "polling_interval": "Polling interval (seconds)"
         }
       }

--- a/doc/ENDPOINTS.md
+++ b/doc/ENDPOINTS.md
@@ -170,7 +170,7 @@ All data endpoints require authentication via Bearer token in the `Authorization
 
 **Examples**:
 - `GET /api/deviceStatuses/123456/1/2025` - Get latest device statuses
-- `GET /api/deviceStatuses/150257/1/2026?fromDate=2026-01-03` - Get device readings for a specific date
+- `GET /api/deviceStatuses/123456/1/2026?fromDate=2026-01-03` - Get device readings for a specific date
 
 **Notes**:
 - The `fromDate` parameter allows retrieving historical device readings for a specific date

--- a/tests/test_cache_refresh_retry.py
+++ b/tests/test_cache_refresh_retry.py
@@ -403,3 +403,201 @@ class TestEnsureMonthlyHistoryCacheRetryBehavior:
                 assert last_update_date_changed_arg is True, (
                     "Both polls must see last_update_date_changed=True"
                 )
+
+
+# ---------------------------------------------------------------------------
+# _lock_current_month_starts_when_previous_complete: anchor correction
+# ---------------------------------------------------------------------------
+
+
+class TestLockCurrentMonthStartsAnchorCorrection:
+    """Verify that completion always fetches the date anchor and corrects the
+    previous month's cache when anchor readings differ from cached values."""
+
+    @pytest.fixture
+    def now(self):
+        return datetime(2026, 4, 3, 12, 0, 0)
+
+    @pytest.fixture
+    def api(self):
+        api = AsyncMock()
+        api.get_device_statuses_for_date = AsyncMock(return_value=[])
+        return api
+
+    def _prev_cache_entry(self):
+        """Build a March 2026 cache entry with stale end readings (698, 116)."""
+        return MonthCacheEntry(
+            month_id="3.2026",
+            year=2026,
+            month=3,
+            start_date="2026-03-01",
+            end_date="2026-03-31",
+            total_usage=22.0,
+            average_usage=306.25,
+            devices=[
+                DeviceReading(id=1001, start=679.0, end=698.0, usage=19.0),
+                DeviceReading(id=1002, start=113.0, end=116.0, usage=3.0),
+            ],
+            finalized=False,
+            state=MONTH_STATE_OPEN,
+            start_locked=False,
+        )
+
+    def _current_cache_entry(self):
+        """Build an April 2026 cache entry with stale start values."""
+        return MonthCacheEntry(
+            month_id="4.2026",
+            year=2026,
+            month=4,
+            start_date="2026-04-01",
+            end_date="2026-04-03",
+            total_usage=5.0,
+            average_usage=None,
+            devices=[
+                DeviceReading(id=1001, start=698.0, end=703.0, usage=5.0),
+                DeviceReading(id=1002, start=116.0, end=116.0, usage=0.0),
+            ],
+            finalized=False,
+            state=MONTH_STATE_OPEN,
+            start_locked=False,
+        )
+
+    async def test_anchor_always_fetched_even_when_cache_has_readings(self, api, now):
+        """Cached end readings present -> anchor is still fetched from API."""
+        anchor_data = [
+            {"deviceNumber": "1001", "currentReadingValue": 699.0},
+            {"deviceNumber": "1002", "currentReadingValue": 116.0},
+        ]
+        api.get_device_statuses_for_date = AsyncMock(return_value=anchor_data)
+
+        cache = {
+            "2026-03": self._prev_cache_entry(),
+            "2026-04": self._current_cache_entry(),
+        }
+        filter_status = [
+            {"deviceNumber": "1001", "currentReadingValue": 707.0},
+            {"deviceNumber": "1002", "currentReadingValue": 118.0},
+        ]
+
+        result = await init_mod._lock_current_month_starts_when_previous_complete(
+            api, cache, filter_status,
+            last_update={"lastSyncDate": "2026-04-03"},
+            energy_usage_data={}, now=now,
+        )
+
+        api.get_device_statuses_for_date.assert_awaited_once()
+        assert result is True
+
+    async def test_prev_month_cache_corrected_when_anchor_differs(self, api, now):
+        """Anchor end readings differ from cached -> previous month total_usage corrected."""
+        anchor_data = [
+            {"deviceNumber": "1001", "currentReadingValue": 699.0},
+            {"deviceNumber": "1002", "currentReadingValue": 116.0},
+        ]
+        api.get_device_statuses_for_date = AsyncMock(return_value=anchor_data)
+
+        cache = {
+            "2026-03": self._prev_cache_entry(),
+            "2026-04": self._current_cache_entry(),
+        }
+        filter_status = [
+            {"deviceNumber": "1001", "currentReadingValue": 707.0},
+            {"deviceNumber": "1002", "currentReadingValue": 118.0},
+        ]
+
+        await init_mod._lock_current_month_starts_when_previous_complete(
+            api, cache, filter_status,
+            last_update={"lastSyncDate": "2026-04-03"},
+            energy_usage_data={}, now=now,
+        )
+
+        prev_entry = cache["2026-03"]
+        assert prev_entry.total_usage == 23.0, (
+            "Previous month total_usage must be corrected from 22 to 23"
+        )
+
+    async def test_current_month_start_inherits_corrected_anchor(self, api, now):
+        """Corrected prev month end readings cascade into current month start."""
+        anchor_data = [
+            {"deviceNumber": "1001", "currentReadingValue": 699.0},
+            {"deviceNumber": "1002", "currentReadingValue": 116.0},
+        ]
+        api.get_device_statuses_for_date = AsyncMock(return_value=anchor_data)
+
+        cache = {
+            "2026-03": self._prev_cache_entry(),
+            "2026-04": self._current_cache_entry(),
+        }
+        filter_status = [
+            {"deviceNumber": "1001", "currentReadingValue": 707.0},
+            {"deviceNumber": "1002", "currentReadingValue": 118.0},
+        ]
+
+        await init_mod._lock_current_month_starts_when_previous_complete(
+            api, cache, filter_status,
+            last_update={"lastSyncDate": "2026-04-03"},
+            energy_usage_data={}, now=now,
+        )
+
+        current_entry = cache["2026-04"]
+        devices_by_id = {}
+        for d in current_entry.devices:
+            devices_by_id[d.id] = d
+
+        assert devices_by_id[1001].start == 699.0, (
+            "Current month device start must use corrected anchor (699, not 698)"
+        )
+
+    async def test_no_correction_when_anchor_matches_cached(self, api, now):
+        """Anchor readings match cached -> no unnecessary cache update."""
+        anchor_data = [
+            {"deviceNumber": "1001", "currentReadingValue": 698.0},
+            {"deviceNumber": "1002", "currentReadingValue": 116.0},
+        ]
+        api.get_device_statuses_for_date = AsyncMock(return_value=anchor_data)
+
+        prev = self._prev_cache_entry()
+        cache = {
+            "2026-03": prev,
+            "2026-04": self._current_cache_entry(),
+        }
+        filter_status = [
+            {"deviceNumber": "1001", "currentReadingValue": 707.0},
+            {"deviceNumber": "1002", "currentReadingValue": 118.0},
+        ]
+
+        await init_mod._lock_current_month_starts_when_previous_complete(
+            api, cache, filter_status,
+            last_update={"lastSyncDate": "2026-04-03"},
+            energy_usage_data={}, now=now,
+        )
+
+        assert cache["2026-03"].total_usage == 22.0, (
+            "Previous month total_usage must stay unchanged when anchor matches"
+        )
+
+    async def test_falls_back_to_cached_when_anchor_fetch_fails(self, api, now):
+        """API error on anchor fetch -> falls back to cached readings."""
+        api.get_device_statuses_for_date = AsyncMock(
+            side_effect=RuntimeError("API down")
+        )
+
+        cache = {
+            "2026-03": self._prev_cache_entry(),
+            "2026-04": self._current_cache_entry(),
+        }
+        filter_status = [
+            {"deviceNumber": "1001", "currentReadingValue": 707.0},
+            {"deviceNumber": "1002", "currentReadingValue": 118.0},
+        ]
+
+        result = await init_mod._lock_current_month_starts_when_previous_complete(
+            api, cache, filter_status,
+            last_update={"lastSyncDate": "2026-04-03"},
+            energy_usage_data={}, now=now,
+        )
+
+        assert result is True, "Should still lock using cached readings as fallback"
+        assert cache["2026-03"].total_usage == 22.0, (
+            "Previous month total_usage must stay unchanged on API failure"
+        )

--- a/tests/test_statistics_reinject.py
+++ b/tests/test_statistics_reinject.py
@@ -185,6 +185,22 @@ class TestStatisticsReinjectDedupBypass:
 
         assert result is True
 
+    @patch("custom_components.mijnted.sensors.base.datetime")
+    async def test_current_month_always_bypasses_injection_guard(self, mock_dt):
+        """Current calendar month -> _has_already_injected_period returns False."""
+        mock_dt.now.return_value = datetime(2026, 4, 7)
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        sensor = self._make_sensor()
+        sensor.coordinator.data = {
+            "statistics_tracking": StatisticsTracking(monthly_usage="4.2026"),
+        }
+
+        result = await sensor._has_already_injected_period(datetime(2026, 4, 1))
+
+        assert result is False, (
+            "Current month must always allow re-injection to keep charts up-to-date"
+        )
+
     async def test_successful_finalize_consumes_reinjected_months(self):
         """Successful import with reinjected month -> consumed hint is removed."""
         sensor = self._make_sensor()


### PR DESCRIPTION
## Summary

- **Entity naming**: Adopt `has_entity_name` pattern and add configurable device name via options flow, aligning with Home Assistant best practices for entity/device naming
- **Fix frozen dashboard statistics**: Allow statistics re-injection for the current calendar month so charts update throughout the month instead of freezing at the first injected value
- **Fix stale completion readings**: Always fetch the authoritative date anchor when a month transitions to COMPLETE_READINGS, instead of relying on cached live-poll readings that can be off by 1 unit; correct the previous month's cache and cascade corrected start values into the current month
- **Anonymize docs**: Replace real residential unit ID in ENDPOINTS.md example

Fixes #46

## Test plan

- [x] All 231 existing tests pass after changes
- [x] New test: current month always bypasses the statistics injection guard
- [x] New tests: anchor is always fetched at completion (5 scenarios: always fetched, cache corrected when anchor differs, current month starts cascade, no-op when anchor matches, fallback on API failure)
- [ ] Verify dashboard chart updates throughout the current month after HA restart
- [ ] Verify that at month boundary, the previous month's total_usage matches the API's `totalEnergyUsage` value
