### PR TITLE
Multi-delivery-type sensor support (warm water, cold water, GJ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,22 @@ During the integration setup in Home Assistant, you'll be prompted to enter your
 
 ## Usage
 
-Once configured, the integration will create several sensors in Home Assistant:
+Once configured, the integration will create several sensors in Home Assistant.
+
+### Multi-meter support
+
+MijnTed can expose multiple **delivery types** (meters) for a residential unit - typically heating plus warm and cold water. The integration discovers all available delivery types and creates **one Home Assistant device with a full sensor set per meter (delivery type/unit)**, rather than only the first one. For example, a home with all three meters (heating reported in both Eenheden and GJ) results in four devices:
+
+- `MijnTed Heating (Eenheden)`
+- `MijnTed Heating (GJ)`
+- `MijnTed Warm water (m³)`
+- `MijnTed Cold water (m³)`
+
+Each device exposes the same sensor suite listed below, with units matching the meter: `m³` (device class `water`) for water meters, and `GJ`/`Units` for heating. Historical statistics are injected per meter for the Home Assistant Energy dashboard.
+
+You can choose which delivery-type/unit combinations to enable through the integration's **Options flow** (Settings > Devices & Services > MijnTed > Configure). By default all discovered combinations are enabled. The MijnTed water page occasionally returns empty data until refreshed; the integration tolerates these transient empty responses and keeps the last-known readings.
+
+The sensors below are created for each enabled meter:
 
 - Detailed references:
   - `doc/SENSORS.md` - full sensor catalog, attributes, and edge cases

--- a/custom_components/mijnted/__init__.py
+++ b/custom_components/mijnted/__init__.py
@@ -2065,6 +2065,41 @@ async def _migrate_legacy_unique_ids(
             )
 
 
+def _migrate_legacy_device(
+    hass: HomeAssistant, entry: ConfigEntry, meters: List[MeterContext]
+) -> None:
+    """Rename or remove the legacy single device left over from the uniform rename.
+
+    Pre-#50 all entities lived on device ``(DOMAIN, residential_unit)``. After
+    namespacing, that device is empty. If the primary meter's namespaced device
+    doesn't exist yet, rename the legacy device onto it (preserving device-level
+    settings); if it already exists (install already upgraded), remove the empty
+    legacy device so it no longer shows up.
+    """
+    target = next((m for m in meters if m.delivery_type is not None), None)
+    residential_unit = entry.data.get("residential_unit")
+    if target is None or not residential_unit:
+        return
+    try:
+        from homeassistant.helpers import device_registry as dr
+    except Exception:  # pragma: no cover - HA always provides this at runtime
+        return
+    registry = dr.async_get(hass)
+    legacy = registry.async_get_device(identifiers={(DOMAIN, residential_unit)})
+    if legacy is None:
+        return
+    new_identifier = (DOMAIN, f"{residential_unit}_{target.delivery_type}_{target.unit_slug}")
+    try:
+        if registry.async_get_device(identifiers={new_identifier}) is not None:
+            registry.async_remove_device(legacy.id)
+            _LOGGER.info("Removed empty legacy MijnTed device %s", legacy.id)
+        else:
+            registry.async_update_device(legacy.id, new_identifiers={new_identifier})
+            _LOGGER.info("Migrated legacy MijnTed device to %s", new_identifier)
+    except Exception as err:
+        _LOGGER.warning("Failed to migrate/remove legacy device: %s", err)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MijnTed from a config entry.
 
@@ -2214,6 +2249,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     meters = await _discover_meters(hass, entry, token_update_callback, credentials_callback)
     await _migrate_legacy_unique_ids(hass, entry, meters)
+    _migrate_legacy_device(hass, entry, meters)
 
     def _make_update_method(meter: MeterContext):
         async def _update() -> Dict[str, Any]:

--- a/custom_components/mijnted/__init__.py
+++ b/custom_components/mijnted/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+import re
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -11,6 +12,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .api import MijntedApi
 from .const import (
     CACHE_HISTORY_MONTHS,
+    CONF_ENABLED_METERS,
     CONF_PASSWORD,
     CONF_POLLING_INTERVAL,
     CONF_USERNAME,
@@ -27,7 +29,7 @@ from .exceptions import (
     MijntedGrantExpiredError,
 )
 from .utils import ApiUtil, DataUtil, DateUtil, TimestampUtil
-from .sensors.base import MijnTedSensor
+from .sensors.base import MijnTedSensor, unit_slug
 from .sensors.models import (
     DeviceReading,
     MONTH_STATE_COMPLETE_READINGS,
@@ -41,9 +43,84 @@ from .sensors.models import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _load_persisted_cache(hass: HomeAssistant, entry_id: str) -> Optional[Dict[str, MonthCacheEntry]]:
+class MeterContext(NamedTuple):
+    """A single (delivery_type, unit) meter to expose as its own device + sensors.
+
+    Attributes:
+        delivery_type: The MijnTed delivery type id (e.g. 1, 2, 3).
+        unit: The selected unit value (e.g. "GJ", "m³", "eenheid"), or None.
+        label: Friendly delivery-type label (e.g. "Heating", "Warm water").
+    """
+
+    delivery_type: Any
+    unit: Optional[str]
+    label: str
+
+    @property
+    def unit_slug(self) -> str:
+        """Id-safe slug of the unit, used in keys/unique_ids/storage."""
+        return unit_slug(self.unit)
+
+    @property
+    def key(self) -> str:
+        """Stable key identifying this meter within a config entry."""
+        return f"{self.delivery_type}_{self.unit_slug}"
+
+    def cache_id(self, entry_id: str) -> str:
+        """Per-meter persistent-storage id (namespaced under the entry)."""
+        return f"{entry_id}_{self.key}"
+
+
+def _entry_store(hass: HomeAssistant, entry_id: str) -> Optional[Dict[str, Any]]:
+    """Return the per-entry data dict in hass.data, or None if absent."""
+    store = hass.data.get(DOMAIN, {}).get(entry_id)
+    return store if isinstance(store, dict) else None
+
+
+def _get_meter_coordinator(
+    hass: HomeAssistant, entry: ConfigEntry, meter_key: str
+) -> Optional[DataUpdateCoordinator]:
+    """Resolve the existing coordinator for a meter, or None if not set up yet."""
+    store = _entry_store(hass, entry.entry_id)
+    if not store:
+        return None
+    return store.get("coordinators", {}).get(meter_key)
+
+
+def _meters_from_detail(
+    delivery_types_detail: List[Dict[str, Any]],
+    enabled_keys: Optional[set] = None,
+) -> List["MeterContext"]:
+    """Build MeterContext list from discovery detail, one per (type, unit).
+
+    Args:
+        delivery_types_detail: Output of api.discover_delivery_types().
+        enabled_keys: Optional set of meter keys to include; None means all.
+
+    Returns:
+        List of MeterContext, one per available (delivery_type, unit) pair. A
+        delivery type that reports no units still yields a single default meter.
+    """
+    meters: List[MeterContext] = []
+    for entry in delivery_types_detail:
+        if not isinstance(entry, dict):
+            continue
+        delivery_type = entry.get("id")
+        label = entry.get("label") or entry.get("model") or f"Type {delivery_type}"
+        units = entry.get("units") or []
+        unit_values = [u.get("value") for u in units if isinstance(u, dict) and u.get("value")]
+        if not unit_values:
+            unit_values = [None]
+        for unit in unit_values:
+            meter = MeterContext(delivery_type=delivery_type, unit=unit, label=label)
+            if enabled_keys is None or meter.key in enabled_keys:
+                meters.append(meter)
+    return meters
+
+
+async def _load_persisted_cache(hass: HomeAssistant, cache_id: str) -> Optional[Dict[str, MonthCacheEntry]]:
     """Load monthly history cache from persistent storage."""
-    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{entry_id}")
+    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{cache_id}")
     try:
         data = await store.async_load()
         if data and isinstance(data, dict):
@@ -73,8 +150,8 @@ async def _load_persisted_cache(hass: HomeAssistant, entry_id: str) -> Optional[
 
 
 async def _save_persisted_cache(
-    hass: HomeAssistant, 
-    entry_id: str, 
+    hass: HomeAssistant,
+    cache_id: str,
     monthly_history_cache: Dict[str, MonthCacheEntry]
 ) -> None:
     """Save monthly history cache to persistent storage."""
@@ -98,7 +175,7 @@ async def _save_persisted_cache(
         _LOGGER.debug("No complete months to persist")
         return
     
-    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{entry_id}")
+    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{cache_id}")
     try:
         await store.async_save({"monthly_history_cache": complete_cache})
         _LOGGER.debug("Saved %d complete months to persistent storage", len(complete_cache))
@@ -106,12 +183,12 @@ async def _save_persisted_cache(
         _LOGGER.warning("Failed to save persisted cache: %s", err)
 
 
-async def _clear_persisted_cache(hass: HomeAssistant, entry_id: str) -> None:
+async def _clear_persisted_cache(hass: HomeAssistant, cache_id: str) -> None:
     """Clear monthly history cache from persistent storage."""
-    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{entry_id}")
+    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{cache_id}")
     try:
         await store.async_save({"monthly_history_cache": {}})
-        _LOGGER.info("Cleared persisted cache for entry %s", entry_id)
+        _LOGGER.info("Cleared persisted cache for %s", cache_id)
     except Exception as err:
         _LOGGER.warning("Failed to clear persisted cache: %s", err)
 
@@ -1395,15 +1472,16 @@ async def _compute_anchor_calculations(
 
 def _load_cache_from_coordinator(
     hass: HomeAssistant,
-    entry: ConfigEntry
+    entry: ConfigEntry,
+    meter_key: str,
 ) -> Tuple[Dict[str, MonthCacheEntry], Optional[str]]:
     """Load monthly history cache and cached_last_update_date from existing coordinator data."""
     monthly_history_cache: Dict[str, MonthCacheEntry] = {}
     cached_last_update_date: Optional[str] = None
 
-    if entry.entry_id in hass.data.get(DOMAIN, {}):
-        existing_coordinator = hass.data[DOMAIN][entry.entry_id]
-        if existing_coordinator and existing_coordinator.data:
+    existing_coordinator = _get_meter_coordinator(hass, entry, meter_key)
+    if existing_coordinator and existing_coordinator.data:
+        if True:  # noqa: SIM102 - keep nested block indentation stable
             cache_data = existing_coordinator.data.get("monthly_history_cache", {})
             cached_last_update_date = existing_coordinator.data.get("cached_last_update_date")
             if cache_data:
@@ -1580,28 +1658,28 @@ def _serialize_statistics_reinject(hints: Dict[str, set[str]]) -> Dict[str, List
 def _get_existing_statistics_reinject(
     hass: HomeAssistant,
     entry: ConfigEntry,
+    meter_key: str,
 ) -> Dict[str, set[str]]:
     """Read pending statistics reinject hints from existing coordinator data."""
-    if entry.entry_id in hass.data.get(DOMAIN, {}):
-        existing_coordinator = hass.data[DOMAIN][entry.entry_id]
-        if existing_coordinator and existing_coordinator.data:
-            return _normalize_statistics_reinject(
-                existing_coordinator.data.get("statistics_reinject")
-            )
+    existing_coordinator = _get_meter_coordinator(hass, entry, meter_key)
+    if existing_coordinator and existing_coordinator.data:
+        return _normalize_statistics_reinject(
+            existing_coordinator.data.get("statistics_reinject")
+        )
     return {}
 
 
 def _get_or_create_statistics_tracking(
     hass: HomeAssistant,
-    entry: ConfigEntry
+    entry: ConfigEntry,
+    meter_key: str,
 ) -> StatisticsTracking:
     """Get existing StatisticsTracking from coordinator or create a new one."""
-    if entry.entry_id in hass.data.get(DOMAIN, {}):
-        existing_coordinator = hass.data[DOMAIN][entry.entry_id]
-        if existing_coordinator and existing_coordinator.data:
-            existing_tracking = existing_coordinator.data.get("statistics_tracking")
-            if isinstance(existing_tracking, StatisticsTracking):
-                return existing_tracking
+    existing_coordinator = _get_meter_coordinator(hass, entry, meter_key)
+    if existing_coordinator and existing_coordinator.data:
+        existing_tracking = existing_coordinator.data.get("statistics_tracking")
+        if isinstance(existing_tracking, StatisticsTracking):
+            return existing_tracking
     return StatisticsTracking(
         monthly_usage=None,
         last_year_monthly_usage=None,
@@ -1618,12 +1696,14 @@ async def _load_or_build_cache(
     last_update: Any,
     energy_usage_data: Dict[str, Any],
     now: datetime,
+    meter_key: str,
+    cache_id: str,
 ) -> Tuple[Dict[str, MonthCacheEntry], bool]:
     """Load cache from coordinator/storage, or build initial. Returns (cache, was_modified)."""
-    monthly_history_cache, _ = _load_cache_from_coordinator(hass, entry)
+    monthly_history_cache, _ = _load_cache_from_coordinator(hass, entry, meter_key)
 
     if not monthly_history_cache:
-        persisted_cache = await _load_persisted_cache(hass, entry.entry_id)
+        persisted_cache = await _load_persisted_cache(hass, cache_id)
         if persisted_cache:
             monthly_history_cache = persisted_cache
             _LOGGER.info("Restored monthly history cache from storage (%d complete months)", len(monthly_history_cache))
@@ -1717,18 +1797,22 @@ async def _ensure_monthly_history_cache(
     last_update: Any,
     energy_usage_data: Dict[str, Any],
     filter_status: List[Dict[str, Any]],
+    meter_key: str = "",
+    cache_id: Optional[str] = None,
 ) -> Tuple[Dict[str, MonthCacheEntry], Optional[str], StatisticsTracking, Dict[str, List[str]]]:
     """Load/build/update/enrich/persist monthly history cache."""
+    if cache_id is None:
+        cache_id = entry.entry_id
     now = datetime.now()
     current_last_update_date = _extract_last_update_date(last_update)
-    _, cached_last_update_date = _load_cache_from_coordinator(hass, entry)
+    _, cached_last_update_date = _load_cache_from_coordinator(hass, entry, meter_key)
     last_update_date_changed = current_last_update_date != cached_last_update_date
 
     current_month_refresh_skipped = False
-    pending_statistics_reinject = _get_existing_statistics_reinject(hass, entry)
+    pending_statistics_reinject = _get_existing_statistics_reinject(hass, entry, meter_key)
     try:
         monthly_history_cache, cache_was_modified = await _load_or_build_cache(
-            api, hass, entry, last_update, energy_usage_data, now
+            api, hass, entry, last_update, energy_usage_data, now, meter_key, cache_id
         )
         usage_snapshot_before_update = _snapshot_historical_month_usage_values(
             monthly_history_cache, now
@@ -1750,7 +1834,7 @@ async def _ensure_monthly_history_cache(
         )
         if cache_was_modified or enrichment_modified:
             try:
-                await _save_persisted_cache(hass, entry.entry_id, monthly_history_cache)
+                await _save_persisted_cache(hass, cache_id, monthly_history_cache)
             except Exception as err:
                 _LOGGER.warning("Failed to persist cache: %s", err)
     except Exception as err:
@@ -1764,7 +1848,7 @@ async def _ensure_monthly_history_cache(
         cached_last_update_date if current_month_refresh_skipped
         else current_last_update_date
     )
-    statistics_tracking = _get_or_create_statistics_tracking(hass, entry)
+    statistics_tracking = _get_or_create_statistics_tracking(hass, entry, meter_key)
     statistics_reinject = _serialize_statistics_reinject(pending_statistics_reinject)
     return (
         monthly_history_cache,
@@ -1797,6 +1881,7 @@ def _build_coordinator_return_dict(
     current_last_update_date: Optional[str],
     statistics_tracking: StatisticsTracking,
     statistics_reinject: Dict[str, List[str]],
+    meter: Optional["MeterContext"] = None,
 ) -> Dict[str, Any]:
     """Build the coordinator data dictionary returned by async_update_data."""
     return {
@@ -1809,6 +1894,9 @@ def _build_coordinator_return_dict(
         "active_model": active_model,
         "delivery_types": delivery_types,
         "delivery_types_detail": delivery_types_detail,
+        "delivery_type": meter.delivery_type if meter else None,
+        "meter_unit": meter.unit if meter else None,
+        "delivery_label": meter.label if meter else None,
         "residential_unit": api.residential_unit,
         "residential_unit_detail": residential_unit_detail_data,
         "usage_this_year": usage_this_year,
@@ -1867,14 +1955,14 @@ def _handle_connection_error(
     hass: HomeAssistant,
     entry: ConfigEntry,
     api: MijntedApi,
-    err: MijntedConnectionError
+    err: MijntedConnectionError,
+    meter_key: str,
 ) -> Dict[str, Any]:
     """Handle connection error: return cached data if available, otherwise raise UpdateFailed."""
     cached_data = None
-    if entry.entry_id in hass.data.get(DOMAIN, {}):
-        coordinator = hass.data[DOMAIN][entry.entry_id]
-        if coordinator.data:
-            cached_data = coordinator.data
+    coordinator = _get_meter_coordinator(hass, entry, meter_key)
+    if coordinator and coordinator.data:
+        cached_data = coordinator.data
 
     token_expired = api.auth.is_access_token_expired() if api.auth else True
 
@@ -1934,13 +2022,56 @@ def _handle_grant_expired(hass: HomeAssistant, entry: ConfigEntry, err: MijntedG
     ) from err
 
 
+async def _migrate_legacy_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, meters: List[MeterContext]
+) -> None:
+    """Rename legacy single-type unique_ids to the namespaced multi-meter scheme.
+
+    The pre-#50 entities used ``mijnted_<sensor_type>`` and belonged to the first
+    delivery type with its default unit. To preserve recorder history and
+    long-term statistics under the uniform rename, migrate those to
+    ``mijnted_<delivery_type>_<unit_slug>_<sensor_type>`` of the primary meter.
+    Entities already namespaced (``mijnted_<digit>_...``) are skipped, making this
+    idempotent across restarts.
+    """
+    target = next((m for m in meters if m.delivery_type is not None), None)
+    if target is None:
+        return
+    try:
+        from homeassistant.helpers import entity_registry as er
+    except Exception:  # pragma: no cover - HA always provides this at runtime
+        return
+    registry = er.async_get(hass)
+    prefix = f"{DOMAIN}_{target.delivery_type}_{target.unit_slug}_"
+    try:
+        registry_entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    except Exception as err:  # pragma: no cover - defensive
+        _LOGGER.debug("Could not enumerate entities for unique_id migration: %s", err)
+        return
+    for reg_entry in registry_entries:
+        unique_id = getattr(reg_entry, "unique_id", "") or ""
+        if not unique_id.startswith(f"{DOMAIN}_"):
+            continue
+        rest = unique_id[len(DOMAIN) + 1:]
+        if re.match(r"^\d+_", rest):
+            continue  # already namespaced by delivery type
+        new_unique_id = f"{prefix}{rest}"
+        try:
+            registry.async_update_entity(reg_entry.entity_id, new_unique_id=new_unique_id)
+            _LOGGER.info("Migrated unique_id %s -> %s", unique_id, new_unique_id)
+        except Exception as err:
+            _LOGGER.warning(
+                "Failed to migrate unique_id %s -> %s: %s", unique_id, new_unique_id, err
+            )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MijnTed from a config entry.
-    
+
     Args:
         hass: Home Assistant instance
         entry: Configuration entry
-        
+
     Returns:
         True if setup was successful, False otherwise
     """
@@ -1978,8 +2109,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise MijntedAuthenticationError("Username and password not found in config entry")
         return (username, password)
     
-    async def async_update_data() -> Dict[str, Any]:
-        """Fetch data from the API and structure it for sensors."""
+    async def async_update_data(meter: MeterContext) -> Dict[str, Any]:
+        """Fetch data from the API for one meter and structure it for sensors."""
         refresh_token_expires_at = _parse_refresh_token_expires_at(entry)
         api = MijntedApi(
             hass=hass,
@@ -1989,8 +2120,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             residential_unit=entry.data.get("residential_unit"),
             refresh_token_expires_at=refresh_token_expires_at,
             token_update_callback=token_update_callback,
-            credentials_callback=credentials_callback
+            credentials_callback=credentials_callback,
+            delivery_type=meter.delivery_type,
+            unit=meter.unit,
         )
+        cache_id = meter.cache_id(entry.entry_id)
         try:
             async with api:
                 await api.authenticate()
@@ -2020,7 +2154,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     statistics_reinject,
                 ) = (
                     await _ensure_monthly_history_cache(
-                        api, hass, entry, last_update, energy_usage_data, filter_status
+                        api, hass, entry, last_update, energy_usage_data, filter_status,
+                        meter.key, cache_id,
                     )
                 )
                 return _build_coordinator_return_dict(
@@ -2046,6 +2181,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     current_last_update_date,
                     statistics_tracking,
                     statistics_reinject,
+                    meter,
                 )
         except MijntedGrantExpiredError as err:
             _handle_grant_expired(hass, entry, err)
@@ -2057,7 +2193,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             raise UpdateFailed(f"Authentication failed: {err}") from err
         except MijntedConnectionError as err:
-            return _handle_connection_error(hass, entry, api, err)
+            return _handle_connection_error(hass, entry, api, err, meter.key)
         except MijntedApiError as err:
             _LOGGER.error(
                 "API error: %s",
@@ -2075,34 +2211,102 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     polling_interval_seconds = entry.data.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL.total_seconds())
     update_interval = timedelta(seconds=int(polling_interval_seconds))
-    
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=DOMAIN,
-        update_method=async_update_data,
-        update_interval=update_interval,
-    )
 
-    await coordinator.async_config_entry_first_refresh()
+    meters = await _discover_meters(hass, entry, token_update_callback, credentials_callback)
+    await _migrate_legacy_unique_ids(hass, entry, meters)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    def _make_update_method(meter: MeterContext):
+        async def _update() -> Dict[str, Any]:
+            return await async_update_data(meter)
+        return _update
+
+    discovery_detail: List[Dict[str, Any]] = []
+    for index, meter in enumerate(meters):
+        coordinator = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_{meter.key}",
+            update_method=_make_update_method(meter),
+            update_interval=update_interval,
+        )
+        # Register before first refresh so per-meter helpers can resolve cached data.
+        hass.data.setdefault(DOMAIN, {}).setdefault(
+            entry.entry_id, {"coordinators": {}, "discovery": [], "meters": []}
+        )
+        hass.data[DOMAIN][entry.entry_id]["coordinators"][meter.key] = coordinator
+        hass.data[DOMAIN][entry.entry_id]["meters"].append(meter)
+        # The primary meter gates entry setup (so a fully-down account retries);
+        # additional meters refresh non-fatally so one flaky meter (e.g. the
+        # intermittently-empty water page) can't block the others.
+        if index == 0:
+            await coordinator.async_config_entry_first_refresh()
+        else:
+            await coordinator.async_refresh()
+        if coordinator.data and coordinator.data.get("delivery_types_detail"):
+            discovery_detail = coordinator.data["delivery_types_detail"]
+
+    if entry.entry_id in hass.data.get(DOMAIN, {}):
+        hass.data[DOMAIN][entry.entry_id]["discovery"] = discovery_detail
 
     await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "button"])
 
     return True
 
+
+async def _discover_meters(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    token_update_callback,
+    credentials_callback,
+) -> List[MeterContext]:
+    """Bootstrap-authenticate, discover delivery types, and resolve enabled meters.
+
+    Falls back to a single default meter (legacy single-type behavior) when
+    discovery is empty or fails, so setup never produces zero entities.
+    """
+    refresh_token_expires_at = _parse_refresh_token_expires_at(entry)
+    api = MijntedApi(
+        hass=hass,
+        client_id=entry.data["client_id"],
+        refresh_token=entry.data["refresh_token"],
+        access_token=entry.data.get("access_token"),
+        residential_unit=entry.data.get("residential_unit"),
+        refresh_token_expires_at=refresh_token_expires_at,
+        token_update_callback=token_update_callback,
+        credentials_callback=credentials_callback,
+    )
+    detail: List[Dict[str, Any]] = []
+    try:
+        async with api:
+            await api.authenticate()
+            _sync_tokens_to_config(hass, entry, api)
+            detail = await api.discover_delivery_types()
+    except Exception as err:
+        _LOGGER.warning(
+            "Delivery-type discovery failed during setup; falling back to single meter: %s",
+            err,
+            extra={"entry_id": entry.entry_id, "error_type": type(err).__name__},
+        )
+
+    enabled = entry.options.get(CONF_ENABLED_METERS)
+    enabled_keys = set(enabled) if enabled else None
+    meters = _meters_from_detail(detail, enabled_keys)
+    if not meters:
+        meters = [MeterContext(delivery_type=None, unit=None, label="MijnTed")]
+    return meters
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload MijnTed config entry.
-    
+
     Args:
         hass: Home Assistant instance
         entry: Configuration entry to unload
-        
+
     Returns:
         True if unload was successful, False otherwise
     """
     unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor", "button"])
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id, None)
     return unload_ok

--- a/custom_components/mijnted/__init__.py
+++ b/custom_components/mijnted/__init__.py
@@ -1290,7 +1290,11 @@ async def _fetch_and_normalize_api_data(api: MijntedApi) -> Dict[str, Any]:
     unit_of_measures_data = _handle_gather_result(
         "unit_of_measures", unit_of_measures_data, [], residential_unit
     )
-    delivery_types = await api.get_delivery_types()
+    # Discover all delivery types with their model and units (issue #50).
+    # discover_delivery_types() also calls get_delivery_types() internally, which
+    # sets api.delivery_type for the single-type endpoints fetched above.
+    delivery_types_detail = await api.discover_delivery_types()
+    delivery_types = [entry["id"] for entry in delivery_types_detail]
     return {
         "energy_usage_data": energy_usage_data,
         "last_update_data": last_update_data,
@@ -1302,6 +1306,7 @@ async def _fetch_and_normalize_api_data(api: MijntedApi) -> Dict[str, Any]:
         "usage_per_room_data": usage_per_room_data,
         "unit_of_measures_data": unit_of_measures_data,
         "delivery_types": delivery_types,
+        "delivery_types_detail": delivery_types_detail,
     }
 
 
@@ -1779,6 +1784,7 @@ def _build_coordinator_return_dict(
     usage_insight_last_year_data: Dict[str, Any],
     active_model: Any,
     delivery_types: List[Any],
+    delivery_types_detail: List[Dict[str, Any]],
     residential_unit_detail_data: Dict[str, Any],
     usage_this_year: Dict[str, Any],
     usage_last_year: Dict[str, Any],
@@ -1802,6 +1808,7 @@ def _build_coordinator_return_dict(
         "usage_insight_last_year": usage_insight_last_year_data,
         "active_model": active_model,
         "delivery_types": delivery_types,
+        "delivery_types_detail": delivery_types_detail,
         "residential_unit": api.residential_unit,
         "residential_unit_detail": residential_unit_detail_data,
         "usage_this_year": usage_this_year,
@@ -2026,6 +2033,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     data["usage_insight_last_year_data"],
                     active_model,
                     data["delivery_types"],
+                    data["delivery_types_detail"],
                     data["residential_unit_detail_data"],
                     usage_this_year,
                     usage_last_year,

--- a/custom_components/mijnted/api.py
+++ b/custom_components/mijnted/api.py
@@ -47,7 +47,7 @@ class MijntedApi:
         credentials_callback: Async callback to retrieve credentials for re-authentication (optional).
     """
 
-    def __init__(self, hass, client_id: str, refresh_token: Optional[str] = None, access_token: Optional[str] = None, residential_unit: Optional[str] = None, refresh_token_expires_at: Optional[datetime] = None, token_update_callback: Optional[Callable[[str, Optional[str], Optional[str], Optional[datetime]], Awaitable[None]]] = None, credentials_callback: Optional[Callable[[], Awaitable[tuple]]] = None):
+    def __init__(self, hass, client_id: str, refresh_token: Optional[str] = None, access_token: Optional[str] = None, residential_unit: Optional[str] = None, refresh_token_expires_at: Optional[datetime] = None, token_update_callback: Optional[Callable[[str, Optional[str], Optional[str], Optional[datetime]], Awaitable[None]]] = None, credentials_callback: Optional[Callable[[], Awaitable[tuple]]] = None, delivery_type: Optional[Any] = None, unit: Optional[str] = None):
         """Initialize Mijnted API client.
         
         Args:
@@ -70,7 +70,13 @@ class MijntedApi:
         self.client_id = client_id.strip()
         self.session: Optional[aiohttp.ClientSession] = None
         self.base_url = API_BASE_URL
-        self.delivery_type: Optional[str] = None
+        # When delivery_type is provided it is "pinned": discovery must not
+        # overwrite it with the first available type (issue #50 multi-meter).
+        self.delivery_type: Optional[Any] = delivery_type
+        self._delivery_type_pinned: bool = delivery_type is not None
+        # Selected unit for this client (e.g. "GJ", "m³", "eenheid"); drives the
+        # optional unitOfMeasure query parameter on data endpoints.
+        self.unit: Optional[str] = unit
         self.token_update_callback = token_update_callback
         self.auth: Optional[MijntedAuth] = None
         self._auth_init_params = {
@@ -256,10 +262,32 @@ class MijntedApi:
         """
         url = f"{self.base_url}/address/deliveryTypes/{self.residential_unit}"
         result = await self._make_request("GET", url)
-        first_item = ListUtil.get_first_item(result)
-        if first_item is not None:
-            self.delivery_type = first_item
+        if not self._delivery_type_pinned:
+            first_item = ListUtil.get_first_item(result)
+            if first_item is not None:
+                self.delivery_type = first_item
         return result if isinstance(result, list) else []
+
+    def _with_unit(self, url: str) -> str:
+        """Append the unitOfMeasure query parameter to a URL when applicable.
+
+        Uses the client's selected unit; only the GJ unit adds the parameter
+        (water types default to m³ and omit it). Preserves any existing query
+        string already present on the URL.
+
+        Args:
+            url: The fully-built request URL.
+
+        Returns:
+            The URL with ``unitOfMeasure=GJ`` appended when the selected unit is
+            GJ, otherwise the URL unchanged.
+        """
+        params = self.unit_query_params(self.unit)
+        if not params:
+            return url
+        separator = "&" if "?" in url else "?"
+        query = "&".join(f"{key}={value}" for key, value in params.items())
+        return f"{url}{separator}{query}"
 
     async def get_energy_usage(self, year: Optional[int] = None) -> Dict[str, Any]:
         """Get energy usage data for a specific year.
@@ -272,7 +300,7 @@ class MijntedApi:
         """
         if year is None:
             year = self._get_current_year()
-        url = f"{self.base_url}/residentialUnitUsage/{year}/{self.residential_unit}/{self.delivery_type}"
+        url = self._with_unit(f"{self.base_url}/residentialUnitUsage/{year}/{self.residential_unit}/{self.delivery_type}")
         return await self._make_request("GET", url)
 
     async def get_last_data_update(self) -> Dict[str, Any]:
@@ -281,7 +309,7 @@ class MijntedApi:
         Returns:
             Dictionary containing last sync date information
         """
-        url = f"{self.base_url}/getLastSyncDate/{self.residential_unit}/{self.delivery_type}/{self._get_current_year()}"
+        url = self._with_unit(f"{self.base_url}/getLastSyncDate/{self.residential_unit}/{self.delivery_type}/{self._get_current_year()}")
         return await self._make_request("GET", url)
 
     async def get_filter_status(self) -> List[Dict[str, Any]]:
@@ -290,7 +318,7 @@ class MijntedApi:
         Returns:
             List of device status objects, empty list if none found
         """
-        url = f"{self.base_url}/deviceStatuses/{self.residential_unit}/{self.delivery_type}/{self._get_current_year()}"
+        url = self._with_unit(f"{self.base_url}/deviceStatuses/{self.residential_unit}/{self.delivery_type}/{self._get_current_year()}")
         result = await self._make_request("GET", url)
         if isinstance(result, list):
             return result
@@ -309,7 +337,7 @@ class MijntedApi:
         try:
             date_str = target_date.strftime(API_DATE_FORMAT)
             year = target_date.year
-            url = f"{self.base_url}/deviceStatuses/{self.residential_unit}/{self.delivery_type}/{year}?fromDate={date_str}"
+            url = self._with_unit(f"{self.base_url}/deviceStatuses/{self.residential_unit}/{self.delivery_type}/{year}?fromDate={date_str}")
             result = await self._make_request("GET", url)
             if isinstance(result, list):
                 return result
@@ -336,7 +364,7 @@ class MijntedApi:
         """
         if year is None:
             year = self._get_current_year()
-        url = f"{self.base_url}/usageInsight/{year}/{self.residential_unit}/{self.delivery_type}"
+        url = self._with_unit(f"{self.base_url}/usageInsight/{year}/{self.residential_unit}/{self.delivery_type}")
         return await self._make_request("GET", url)
 
     async def get_active_model(self) -> Dict[str, Any]:
@@ -369,7 +397,7 @@ class MijntedApi:
         """
         if year is None:
             year = self._get_current_year()
-        url = f"{self.base_url}/residentialUnitUsagePerRoom/{year}/{self.residential_unit}/{self.delivery_type}"
+        url = self._with_unit(f"{self.base_url}/residentialUnitUsagePerRoom/{year}/{self.residential_unit}/{self.delivery_type}")
         return await self._make_request("GET", url)
 
     async def get_unit_of_measures(self) -> List[Dict[str, Any]]:

--- a/custom_components/mijnted/api.py
+++ b/custom_components/mijnted/api.py
@@ -11,6 +11,8 @@ from .const import (
     API_DATE_FORMAT,
     AUTHORIZATION_SCHEME_BEARER,
     CONTENT_TYPE_JSON,
+    DELIVERY_TYPE_MODEL_LABELS,
+    DELIVERY_UNIT_GJ,
     HTTP_STATUS_OK,
     HTTP_STATUS_UNAUTHORIZED,
     REQUEST_TIMEOUT,
@@ -383,6 +385,112 @@ class MijntedApi:
             return result
         value = ApiUtil.extract_value(result, [])
         return value if isinstance(value, list) else []
+
+    @staticmethod
+    def _delivery_type_label(model: Optional[str]) -> Optional[str]:
+        """Map an activeModel code to a friendly delivery-type label.
+
+        Args:
+            model: The activeModel code returned for a delivery type (e.g. "F59").
+
+        Returns:
+            A friendly label (e.g. "Heating"), or the original model code if unknown.
+        """
+        if not isinstance(model, str) or not model:
+            return None
+        return DELIVERY_TYPE_MODEL_LABELS.get(model.upper(), model)
+
+    @staticmethod
+    def unit_query_params(unit: Optional[str]) -> Optional[Dict[str, str]]:
+        """Return the query params for a unit, appending unitOfMeasure only for GJ.
+
+        Water delivery types default to m3 and must not receive the parameter;
+        only the heating type's GJ unit requires it (see issue #50).
+
+        Args:
+            unit: The selected unit value (e.g. "GJ", "m3", "eenheid").
+
+        Returns:
+            ``{"unitOfMeasure": "GJ"}`` when the unit is GJ, otherwise None.
+        """
+        if isinstance(unit, str) and unit.upper() == DELIVERY_UNIT_GJ:
+            return {"unitOfMeasure": DELIVERY_UNIT_GJ}
+        return None
+
+    async def get_active_model_for(self, delivery_type: Any) -> Optional[str]:
+        """Get the active model code for a specific delivery type.
+
+        Args:
+            delivery_type: The delivery type identifier (e.g. 1, 2, 3).
+
+        Returns:
+            The active model code (e.g. "F59"), or None if unavailable.
+        """
+        url = f"{self.base_url}/activeModel/{self.residential_unit}/{delivery_type}"
+        result = await self._make_request("GET", url)
+        return ApiUtil.extract_value(result, None)
+
+    async def get_unit_of_measures_for(
+        self, delivery_type: Any, year: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get available units of measure for a specific delivery type.
+
+        Args:
+            delivery_type: The delivery type identifier (e.g. 1, 2, 3).
+            year: Year to query (defaults to current year).
+
+        Returns:
+            List of unit-of-measure objects, empty list if none found.
+        """
+        if year is None:
+            year = self._get_current_year()
+        url = f"{self.base_url}/unitOfMeasures/{self.residential_unit}/{delivery_type}/{year}"
+        result = await self._make_request("GET", url)
+        if isinstance(result, list):
+            return result
+        value = ApiUtil.extract_value(result, [])
+        return value if isinstance(value, list) else []
+
+    async def discover_delivery_types(self) -> List[Dict[str, Any]]:
+        """Discover all delivery types with their model and available units.
+
+        Calls the delivery-types endpoint and, for each type, fetches the
+        active model and available units so callers can build a sensor set per
+        delivery type (issue #50). Per-type failures are tolerated: a type with
+        a transient error still appears with whatever data was retrieved.
+
+        Returns:
+            List of dicts shaped as
+            ``{"id", "model", "label", "units"}`` for each delivery type.
+        """
+        raw_types = await self.get_delivery_types()
+        discovered: List[Dict[str, Any]] = []
+        for delivery_type in raw_types:
+            try:
+                model = await self.get_active_model_for(delivery_type)
+            except MijntedApiError as err:
+                _LOGGER.warning(
+                    "Failed to fetch active model for delivery type %s: %s",
+                    delivery_type, err,
+                    extra={"delivery_type": delivery_type, "residential_unit": self.residential_unit},
+                )
+                model = None
+            try:
+                units = await self.get_unit_of_measures_for(delivery_type)
+            except MijntedApiError as err:
+                _LOGGER.warning(
+                    "Failed to fetch units for delivery type %s: %s",
+                    delivery_type, err,
+                    extra={"delivery_type": delivery_type, "residential_unit": self.residential_unit},
+                )
+                units = []
+            discovered.append({
+                "id": delivery_type,
+                "model": model,
+                "label": self._delivery_type_label(model),
+                "units": units,
+            })
+        return discovered
 
     def _headers(self) -> Dict[str, str]:
         """Returns authorization headers dict."""

--- a/custom_components/mijnted/button.py
+++ b/custom_components/mijnted/button.py
@@ -20,10 +20,22 @@ async def async_setup_entry(
         entry: Configuration entry
         async_add_entities: Callback to add entities
     """
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    
-    buttons: List[ButtonEntity] = [
-        MijnTedResetStatisticsButton(coordinator, hass=hass, entry_id=entry.entry_id)
-    ]
-    
+    store = hass.data[DOMAIN][entry.entry_id]
+    coordinators = store["coordinators"]
+    meters = store["meters"]
+
+    buttons: List[ButtonEntity] = []
+    for meter in meters:
+        coordinator = coordinators.get(meter.key)
+        if coordinator is None:
+            continue
+        buttons.append(
+            MijnTedResetStatisticsButton(
+                coordinator,
+                hass=hass,
+                entry_id=entry.entry_id,
+                cache_id=meter.cache_id(entry.entry_id),
+            )
+        )
+
     async_add_entities(buttons, True)

--- a/custom_components/mijnted/config_flow.py
+++ b/custom_components/mijnted/config_flow.py
@@ -10,8 +10,10 @@ from homeassistant.const import CONF_CLIENT_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    CONF_ENABLED_METERS,
     CONF_PASSWORD,
     CONF_POLLING_INTERVAL,
     CONF_USERNAME,
@@ -21,6 +23,7 @@ from .const import (
     MIN_POLLING_INTERVAL,
 )
 from .auth import MijntedAuth
+from .sensors.base import unit_slug
 from .exceptions import (
     MijntedApiError,
     MijntedAuthenticationError,
@@ -261,6 +264,29 @@ class MijnTedOptionsFlowHandler(config_entries.OptionsFlow):
         """
         self._config_entry = config_entry
 
+    def _discovered_meter_choices(self) -> Dict[str, str]:
+        """Build {meter_key: label} choices from discovered delivery types.
+
+        Reads discovery detail stashed in hass.data at setup. Returns an empty
+        dict when discovery is unavailable (so the selector is omitted).
+        """
+        choices: Dict[str, str] = {}
+        store = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+        detail = store.get("discovery", []) if isinstance(store, dict) else []
+        for item in detail:
+            if not isinstance(item, dict):
+                continue
+            delivery_type = item.get("id")
+            label = item.get("label") or item.get("model") or f"Type {delivery_type}"
+            units = item.get("units") or []
+            unit_values = [u.get("value") for u in units if isinstance(u, dict) and u.get("value")]
+            if not unit_values:
+                unit_values = [None]
+            for unit in unit_values:
+                key = f"{delivery_type}_{unit_slug(unit)}"
+                choices[key] = f"{label} ({unit})" if unit else label
+        return choices
+
     async def async_step_init(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Manage the options.
 
@@ -270,29 +296,44 @@ class MijnTedOptionsFlowHandler(config_entries.OptionsFlow):
         Returns:
             FlowResult: The next step in the options flow.
         """
+        meter_choices = self._discovered_meter_choices()
+
         if user_input is not None:
-            updated_data = {**self.config_entry.data, **user_input}
+            updated_options = {**self.config_entry.options}
+            updated_data = {**self.config_entry.data}
+            if CONF_POLLING_INTERVAL in user_input:
+                updated_data[CONF_POLLING_INTERVAL] = user_input[CONF_POLLING_INTERVAL]
+            if CONF_ENABLED_METERS in user_input:
+                updated_options[CONF_ENABLED_METERS] = user_input[CONF_ENABLED_METERS]
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 data=updated_data,
+                options=updated_options,
             )
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data={})
 
+        schema: Dict[Any, Any] = {
+            vol.Optional(
+                CONF_POLLING_INTERVAL,
+                default=self.config_entry.data.get(
+                    CONF_POLLING_INTERVAL,
+                    DEFAULT_POLLING_INTERVAL.total_seconds()
+                ),
+            ): vol.All(
+                vol.Coerce(int),
+                vol.Range(min=MIN_POLLING_INTERVAL, max=MAX_POLLING_INTERVAL)
+            )
+        }
+        if meter_choices:
+            current = self.config_entry.options.get(
+                CONF_ENABLED_METERS, list(meter_choices.keys())
+            )
+            schema[
+                vol.Optional(CONF_ENABLED_METERS, default=current)
+            ] = cv.multi_select(meter_choices)
+
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_POLLING_INTERVAL,
-                        default=self.config_entry.data.get(
-                            CONF_POLLING_INTERVAL,
-                            DEFAULT_POLLING_INTERVAL.total_seconds()
-                        ),
-                    ): vol.All(
-                        vol.Coerce(int),
-                        vol.Range(min=MIN_POLLING_INTERVAL, max=MAX_POLLING_INTERVAL)
-                    )
-                }
-            ),
+            data_schema=vol.Schema(schema),
         )

--- a/custom_components/mijnted/config_flow.py
+++ b/custom_components/mijnted/config_flow.py
@@ -311,7 +311,9 @@ class MijnTedOptionsFlowHandler(config_entries.OptionsFlow):
                 options=updated_options,
             )
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            return self.async_create_entry(title="", data={})
+            # Return the same options so the flow result does not blank them out
+            # (async_create_entry sets entry.options to whatever it is given).
+            return self.async_create_entry(title="", data=updated_options)
 
         schema: Dict[Any, Any] = {
             vol.Optional(

--- a/custom_components/mijnted/const.py
+++ b/custom_components/mijnted/const.py
@@ -70,6 +70,9 @@ TIMESTAMP_FORMAT_ISO_Z = "%Y-%m-%dT%H:%M:%SZ"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_POLLING_INTERVAL = "polling_interval"
+# Options-flow key: list of enabled meter keys ("<delivery_type>_<unit_slug>").
+# Absent/empty means "all discovered meters" (issue #50).
+CONF_ENABLED_METERS = "enabled_meters"
 
 # Azure B2C authentication constants
 AUTH_TENANT_NAME = "mytedprod"

--- a/custom_components/mijnted/const.py
+++ b/custom_components/mijnted/const.py
@@ -46,6 +46,19 @@ STORAGE_KEY = f"{DOMAIN}_monthly_cache"
 MONTH_YEAR_PARTS_COUNT = 2
 DEFAULT_START_VALUE = 0.0
 
+# Delivery types (issue #50: multi-delivery-type support)
+# The ?unitOfMeasure=GJ query parameter is only appended for the heating delivery
+# type when the GJ unit is selected; water types default to m3 and omit it.
+DELIVERY_UNIT_GJ = "GJ"
+# Maps the activeModel code returned per delivery type to a friendly label.
+DELIVERY_TYPE_MODEL_LABELS = {
+    "F59": "Heating",
+    "WMZ": "Heating",
+    "WMZF": "Heating",
+    "WWZ": "Warm water",
+    "KWZ": "Cold water",
+}
+
 # Date format for API requests and storage
 API_DATE_FORMAT = "%Y-%m-%d"
 API_LAST_SYNC_DATE_FORMAT = "%d/%m/%Y"

--- a/custom_components/mijnted/manifest.json
+++ b/custom_components/mijnted/manifest.json
@@ -7,5 +7,5 @@
     "iot_class": "cloud_polling",
     "config_flow": true,
     "requirements": ["aiohttp", "PyJWT", "pkce", "requests"],
-    "version": "1.0.25"
+    "version": "1.1.0"
 }

--- a/custom_components/mijnted/manifest.json
+++ b/custom_components/mijnted/manifest.json
@@ -7,5 +7,5 @@
     "iot_class": "cloud_polling",
     "config_flow": true,
     "requirements": ["aiohttp", "PyJWT", "pkce", "requests"],
-    "version": "1.2.0"
+    "version": "1.2.1"
 }

--- a/custom_components/mijnted/manifest.json
+++ b/custom_components/mijnted/manifest.json
@@ -7,5 +7,5 @@
     "iot_class": "cloud_polling",
     "config_flow": true,
     "requirements": ["aiohttp", "PyJWT", "pkce", "requests"],
-    "version": "1.1.0"
+    "version": "1.2.0"
 }

--- a/custom_components/mijnted/sensor.py
+++ b/custom_components/mijnted/sensor.py
@@ -34,8 +34,26 @@ async def async_setup_entry(
         entry: Configuration entry
         async_add_entities: Callback to add entities
     """
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    
+    store = hass.data[DOMAIN][entry.entry_id]
+    coordinators = store["coordinators"]
+    meters = store["meters"]
+
+    sensors: List[SensorEntity] = []
+    for meter in meters:
+        coordinator = coordinators.get(meter.key)
+        if coordinator is None:
+            continue
+        sensors.extend(_build_meter_sensors(coordinator))
+
+    async_add_entities(sensors, True)
+
+
+def _build_meter_sensors(coordinator) -> List[SensorEntity]:
+    """Build the full sensor set for a single meter's coordinator.
+
+    Meter identity (delivery type / unit / label) is derived by each sensor from
+    the per-meter coordinator data, so unique_ids and devices are namespaced.
+    """
     sensors: List[SensorEntity] = [
         MijnTedMonthlyUsageSensor(coordinator),
         MijnTedLastUpdateSensor(coordinator),
@@ -50,8 +68,9 @@ async def async_setup_entry(
         MijnTedLastYearMonthlyUsageSensor(coordinator),
         MijnTedLatestAvailableInsightSensor(coordinator)
     ]
-    
-    filter_status = coordinator.data.get("filter_status", [])
+
+    data = coordinator.data or {}
+    filter_status = data.get("filter_status", [])
     if isinstance(filter_status, list):
         seen_devices = set()
         for device in filter_status:
@@ -62,5 +81,5 @@ async def async_setup_entry(
                     if device_id not in seen_devices:
                         seen_devices.add(device_id)
                         sensors.append(MijnTedDeviceSensor(coordinator, device_id))
-    
-    async_add_entities(sensors, True)
+
+    return sensors

--- a/custom_components/mijnted/sensor.py
+++ b/custom_components/mijnted/sensor.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+from .sensors.base import is_superseded_meter, radiographic_rooms
 from .sensors import (
     MijnTedMonthlyUsageSensor,
     MijnTedLastUpdateSensor,
@@ -72,9 +73,12 @@ def _build_meter_sensors(coordinator) -> List[SensorEntity]:
     data = coordinator.data or {}
     filter_status = data.get("filter_status", [])
     if isinstance(filter_status, list):
+        radio_rooms = radiographic_rooms(filter_status)
         seen_devices = set()
         for device in filter_status:
             if isinstance(device, dict):
+                if is_superseded_meter(device, radio_rooms):
+                    continue
                 device_number = device.get("deviceNumber")
                 if device_number is not None:
                     device_id = str(device_number)

--- a/custom_components/mijnted/sensors/base.py
+++ b/custom_components/mijnted/sensors/base.py
@@ -1,10 +1,12 @@
 import logging
+import re
 from datetime import date, datetime, time, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple, NamedTuple
 
 from homeassistant.components.recorder.models import StatisticData, StatisticMetaData, StatisticMeanType
 from homeassistant.components.recorder.statistics import async_import_statistics
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import UnitOfVolume
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
@@ -15,6 +17,37 @@ from ..const import (
     DOMAIN,
     UNIT_MIJNTED,
 )
+
+
+def unit_slug(unit: Optional[str]) -> str:
+    """Return an id-safe slug for a unit value (e.g. 'm³' -> 'm3', 'GJ' -> 'gj')."""
+    if not unit:
+        return "default"
+    slug = unit.strip().lower().replace("³", "3").replace("²", "2")
+    slug = re.sub(r"[^a-z0-9]+", "_", slug).strip("_")
+    return slug or "default"
+
+
+def native_unit_for(unit: Optional[str]) -> str:
+    """Map a MijnTed unit value to the Home Assistant native unit string.
+
+    Water meters report m³; heating reports GJ or Eenheden ("Units").
+    """
+    if not unit:
+        return UNIT_MIJNTED
+    normalized = unit.strip().lower()
+    if normalized in ("m³", "m3"):
+        return UnitOfVolume.CUBIC_METERS
+    if normalized == "gj":
+        return "GJ"
+    return UNIT_MIJNTED
+
+
+def device_class_for(unit: Optional[str]) -> Optional[SensorDeviceClass]:
+    """Return the SensorDeviceClass for a unit, or None when not applicable."""
+    if unit and unit.strip().lower() in ("m³", "m3"):
+        return SensorDeviceClass.WATER
+    return None
 from ..utils import DateUtil, DataUtil
 from .models import (
     CurrentData,
@@ -60,19 +93,48 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
         name: Display name for the sensor entity.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], sensor_type: str, name: str) -> None:
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[Dict[str, Any]],
+        sensor_type: str,
+        name: str,
+        delivery_type: Any = None,
+        unit: Optional[str] = None,
+        label: Optional[str] = None,
+    ) -> None:
         """Initialize the sensor.
-        
+
         Args:
             coordinator: Data update coordinator
             sensor_type: Type identifier for the sensor
             name: Display name for the sensor
+            delivery_type: Delivery type id this meter belongs to (None = legacy single-type)
+            unit: Selected unit value for this meter (e.g. "m³", "GJ")
+            label: Friendly delivery-type label (e.g. "Heating", "Warm water")
         """
         super().__init__(coordinator)
         self.sensor_type = sensor_type
         self._name = name
-        self._attr_unique_id = f"{DOMAIN}_{sensor_type.lower()}"
+        # Meter identity may be passed explicitly or, by default, derived from
+        # the per-meter coordinator's data (populated before platform setup).
+        if delivery_type is None and getattr(coordinator, "data", None):
+            delivery_type = coordinator.data.get("delivery_type")
+            unit = coordinator.data.get("meter_unit")
+            label = coordinator.data.get("delivery_label")
+        self.delivery_type = delivery_type
+        self.meter_unit = unit
+        self.meter_label = label
+        self._attr_unique_id = self._namespaced_unique_id(sensor_type, delivery_type, unit)
         self._last_known_value = None
+
+    @staticmethod
+    def _namespaced_unique_id(
+        sensor_type: str, delivery_type: Any = None, unit: Optional[str] = None
+    ) -> str:
+        """Return the unique_id for a sensor, namespaced per meter when applicable."""
+        if delivery_type is None:
+            return f"{DOMAIN}_{sensor_type.lower()}"
+        return f"{DOMAIN}_{delivery_type}_{unit_slug(unit)}_{sensor_type.lower()}"
 
     @staticmethod
     def _build_device_name_from_address(residential_unit_detail: Dict[str, Any]) -> str:
@@ -92,8 +154,18 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
         return f"MijnTed - {', '.join(address_parts)}" if address_parts else "MijnTed"
 
     @staticmethod
-    def _build_device_info(data: Optional[Dict[str, Any]]) -> DeviceInfo:
-        """Build device information from coordinator data."""
+    def _build_device_info(
+        data: Optional[Dict[str, Any]],
+        delivery_type: Any = None,
+        unit: Optional[str] = None,
+        label: Optional[str] = None,
+    ) -> DeviceInfo:
+        """Build device information from coordinator data.
+
+        When ``delivery_type`` is provided the device is namespaced per meter so
+        each delivery type/unit appears as its own Home Assistant device
+        (issue #50); otherwise the legacy single-device identifier is used.
+        """
         if not data:
             return DeviceInfo(
                 identifiers={(DOMAIN, "unknown")},
@@ -108,31 +180,65 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
         if isinstance(residential_unit_detail, dict):
             device_name = MijnTedSensor._build_device_name_from_address(residential_unit_detail)
 
+        # Fall back to meter identity carried in coordinator data (e.g. for the
+        # reset button, which builds device_info statically).
+        if delivery_type is None:
+            delivery_type = data.get("delivery_type")
+            unit = data.get("meter_unit")
+            label = data.get("delivery_label")
+
+        if delivery_type is None:
+            identifiers = {(DOMAIN, residential_unit)}
+        else:
+            identifiers = {(DOMAIN, f"{residential_unit}_{delivery_type}_{unit_slug(unit)}")}
+            suffix_parts = [part for part in (label, f"({unit})" if unit else None) if part]
+            if suffix_parts:
+                device_name = f"{device_name} {' '.join(suffix_parts)}"
+
         return DeviceInfo(
-            identifiers={(DOMAIN, residential_unit)},
+            identifiers=identifiers,
             name=device_name,
             manufacturer="MijnTed",
             model=data.get("active_model", "Unknown"),
         )
-    
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information.
-        
+
         Returns:
             DeviceInfo object with device identifiers and details
         """
-        return self._build_device_info(self.coordinator.data)
+        return self._build_device_info(
+            self.coordinator.data, self.delivery_type, self.meter_unit, self.meter_label
+        )
 
     @property
     def name(self) -> str:
         """Return the name of the sensor.
-        
+
         Returns:
-            Formatted sensor name with "MijnTed" prefix
+            Formatted sensor name, prefixed with "MijnTed" and the meter label
+            so entities are unambiguous across delivery types.
         """
+        label = getattr(self, "meter_label", None)
+        if label:
+            return f"MijnTed {label} {self._name}"
         return f"MijnTed {self._name}"
     
+    @property
+    def device_class(self) -> Optional[SensorDeviceClass]:
+        """Return the sensor device class.
+
+        Honors an explicitly set ``_attr_device_class`` (e.g. timestamp
+        diagnostics); otherwise derives it from the meter unit so water meters
+        report ``water`` (issue #50).
+        """
+        explicit = getattr(self, "_attr_device_class", None)
+        if explicit is not None:
+            return explicit
+        return device_class_for(getattr(self, "meter_unit", None))
+
     @property
     def available(self) -> bool:
         """Return True if sensor has fresh data from coordinator.
@@ -391,7 +497,7 @@ class MijnTedSensor(CoordinatorEntity, SensorEntity):
             name=self.name,
             source="recorder",
             statistic_id=self.entity_id,
-            unit_of_measurement=UNIT_MIJNTED,
+            unit_of_measurement=native_unit_for(getattr(self, "meter_unit", None)),
             mean_type=mean_type,
             unit_class=None
         )

--- a/custom_components/mijnted/sensors/base.py
+++ b/custom_components/mijnted/sensors/base.py
@@ -43,6 +43,20 @@ def native_unit_for(unit: Optional[str]) -> str:
     return UNIT_MIJNTED
 
 
+def display_precision_for(unit: Optional[str]) -> int:
+    """Return the suggested display precision (decimal places) for a unit.
+
+    Water (m³) and heating (GJ) carry fractional readings, so they are shown
+    with 3 decimals; otherwise the count-based "Units" stay whole numbers.
+    """
+    if not unit:
+        return 0
+    normalized = unit.strip().lower()
+    if normalized in ("m³", "m3", "gj"):
+        return 3
+    return 0
+
+
 def device_class_for(unit: Optional[str]) -> Optional[SensorDeviceClass]:
     """Return the SensorDeviceClass for a unit, or None when not applicable."""
     if unit and unit.strip().lower() in ("m³", "m3"):

--- a/custom_components/mijnted/sensors/base.py
+++ b/custom_components/mijnted/sensors/base.py
@@ -48,6 +48,29 @@ def device_class_for(unit: Optional[str]) -> Optional[SensorDeviceClass]:
     if unit and unit.strip().lower() in ("m³", "m3"):
         return SensorDeviceClass.WATER
     return None
+
+
+def radiographic_rooms(filter_status: Any) -> set:
+    """Return the set of room codes that contain a radiographic meter."""
+    if not isinstance(filter_status, list):
+        return set()
+    return {
+        device.get("room")
+        for device in filter_status
+        if isinstance(device, dict) and device.get("radiographicMeter")
+    }
+
+
+def is_superseded_meter(device: Dict[str, Any], radio_rooms: set) -> bool:
+    """Return True for an old non-radiographic meter replaced by a radio one.
+
+    A non-radiographic meter is considered superseded when a radiographic meter
+    exists in the same room (the decommissioned mechanical meter the radio one
+    replaced). Standalone non-radiographic meters are kept.
+    """
+    if not isinstance(device, dict) or device.get("radiographicMeter"):
+        return False
+    return device.get("room") in radio_rooms
 from ..utils import DateUtil, DataUtil
 from .models import (
     CurrentData,

--- a/custom_components/mijnted/sensors/button.py
+++ b/custom_components/mijnted/sensors/button.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 from homeassistant.helpers.storage import Store
 from ..const import DOMAIN
-from .base import MijnTedSensor
+from .base import MijnTedSensor, unit_slug
 from .models import StatisticsTracking
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,30 +28,41 @@ class MijnTedResetStatisticsButton(CoordinatorEntity, ButtonEntity):
     """
     
     def __init__(
-        self, 
+        self,
         coordinator: DataUpdateCoordinator[Dict[str, Any]],
         hass: Optional[HomeAssistant] = None,
-        entry_id: Optional[str] = None
+        entry_id: Optional[str] = None,
+        cache_id: Optional[str] = None,
     ) -> None:
         """Initialize the reset statistics button.
-        
+
         Args:
             coordinator: Data update coordinator
             hass: Home Assistant instance (optional, will try to get from coordinator)
             entry_id: Config entry ID (optional, will try to find from coordinator)
+            cache_id: Per-meter persistent-storage id to clear on press
         """
         super().__init__(coordinator)
-        self._attr_unique_id = f"{DOMAIN}_reset_statistics"
-        self._attr_name = "MijnTed reset statistics"
+        data = coordinator.data or {}
+        delivery_type = data.get("delivery_type")
+        label = data.get("delivery_label")
+        if delivery_type is None:
+            self._attr_unique_id = f"{DOMAIN}_reset_statistics"
+        else:
+            unit_part = unit_slug(data.get("meter_unit"))
+            self._attr_unique_id = f"{DOMAIN}_{delivery_type}_{unit_part}_reset_statistics"
+        prefix = f"MijnTed {label} " if label else "MijnTed "
+        self._attr_name = f"{prefix}reset statistics"
         self._attr_icon = "mdi:refresh"
         self._attr_entity_category = EntityCategory.CONFIG
         self._hass = hass
         self._entry_id = entry_id
-    
+        self._cache_id = cache_id or entry_id
+
     @property
     def device_info(self):
         """Return device information.
-        
+
         Returns:
             DeviceInfo object with device identifiers and details
         """
@@ -69,22 +80,15 @@ class MijnTedResetStatisticsButton(CoordinatorEntity, ButtonEntity):
             return
         
         hass = self._hass
-        entry_id = self._entry_id
-        
         if not hass and hasattr(self, 'hass'):
             hass = self.hass
-        
-        if not entry_id and hass:
-            for entry_id_candidate, coordinator_candidate in hass.data.get(DOMAIN, {}).items():
-                if coordinator_candidate is self.coordinator:
-                    entry_id = entry_id_candidate
-                    break
-        
-        if hass and entry_id:
+
+        cache_id = self._cache_id
+        if hass and cache_id:
             try:
-                store = Store(hass, _STORAGE_VERSION, f"{_STORAGE_KEY}_{entry_id}")
+                store = Store(hass, _STORAGE_VERSION, f"{_STORAGE_KEY}_{cache_id}")
                 await store.async_save({"monthly_history_cache": {}})
-                _LOGGER.info("Cleared persisted cache storage")
+                _LOGGER.info("Cleared persisted cache storage for %s", cache_id)
             except Exception as err:
                 _LOGGER.warning("Failed to clear persisted cache: %s", err)
         

--- a/custom_components/mijnted/sensors/device.py
+++ b/custom_components/mijnted/sensors/device.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .base import MijnTedSensor
+from .base import MijnTedSensor, unit_slug
 from ..const import DOMAIN, UNIT_MIJNTED
 from ..utils import TranslationUtil
 
@@ -15,17 +15,30 @@ class MijnTedDeviceSensor(MijnTedSensor):
         device_number: Zero-based index or identifier of the device in the filter_status list.
     """
     
-    def __init__(self, coordinator: DataUpdateCoordinator[Dict[str, Any]], device_number: str) -> None:
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[Dict[str, Any]],
+        device_number: str,
+        delivery_type: Any = None,
+        unit: Optional[str] = None,
+        label: Optional[str] = None,
+    ) -> None:
         """Initialize the device sensor.
-        
+
         Args:
             coordinator: Data update coordinator
             device_number: Device number identifier
+            delivery_type: Delivery type id this meter belongs to
+            unit: Selected unit value for this meter
+            label: Friendly delivery-type label
         """
         super().__init__(
             coordinator,
             f"device_{device_number}",
-            f"device {device_number}"
+            f"device {device_number}",
+            delivery_type=delivery_type,
+            unit=unit,
+            label=label,
         )
         self.device_number = device_number
         self._attr_icon = "mdi:radiator"
@@ -53,11 +66,14 @@ class MijnTedDeviceSensor(MijnTedSensor):
             Unique identifier string based on room and device number
         """
         device_data = self._device_data
+        prefix = f"{DOMAIN}"
+        if self.delivery_type is not None:
+            prefix = f"{DOMAIN}_{self.delivery_type}_{unit_slug(self.meter_unit)}"
         if device_data and device_data.get("room"):
             room = device_data.get("room", "").lower().replace(" ", "_")
             room = "".join(c if c.isalnum() or c == "_" else "_" for c in room)
-            return f"{DOMAIN}_device_{room}_{self.device_number}"
-        return f"{DOMAIN}_device_{self.device_number}"
+            return f"{prefix}_device_{room}_{self.device_number}"
+        return f"{prefix}_device_{self.device_number}"
 
     @property
     def name(self) -> str:
@@ -67,12 +83,13 @@ class MijnTedDeviceSensor(MijnTedSensor):
             Formatted sensor name with room name if available, otherwise device number
         """
         device_data = self._device_data
+        label_prefix = f"MijnTed {self.meter_label} " if self.meter_label else "MijnTed "
         if device_data and device_data.get("room"):
             room_code = device_data['room']
             hass = getattr(self.coordinator, 'hass', None)
             room_name = TranslationUtil.translate_room_code(room_code, hass)
-            return f"MijnTed device {room_name}"
-        return f"MijnTed device {self.device_number}"
+            return f"{label_prefix}device {room_name}"
+        return f"{label_prefix}device {self.device_number}"
 
     @property
     def state(self) -> Any:

--- a/custom_components/mijnted/sensors/device.py
+++ b/custom_components/mijnted/sensors/device.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .base import MijnTedSensor, device_class_for, is_superseded_meter, radiographic_rooms, unit_slug
+from .base import MijnTedSensor, device_class_for, display_precision_for, is_superseded_meter, radiographic_rooms, unit_slug
 from ..const import DOMAIN, UNIT_MIJNTED
 from ..utils import TranslationUtil
 
@@ -41,7 +41,7 @@ class MijnTedDeviceSensor(MijnTedSensor):
             label=label,
         )
         self.device_number = device_number
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = display_precision_for(self.meter_unit)
 
     @property
     def icon(self) -> str:

--- a/custom_components/mijnted/sensors/device.py
+++ b/custom_components/mijnted/sensors/device.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .base import MijnTedSensor, device_class_for, unit_slug
+from .base import MijnTedSensor, device_class_for, is_superseded_meter, radiographic_rooms, unit_slug
 from ..const import DOMAIN, UNIT_MIJNTED
 from ..utils import TranslationUtil
 
@@ -102,16 +102,19 @@ class MijnTedDeviceSensor(MijnTedSensor):
         return f"{label_prefix}device {self.device_number}"
 
     def _room_meter_count(self, room_code: Any) -> int:
-        """Count how many meters in filter_status share the given room code."""
+        """Count visible (non-superseded) meters that share the given room code."""
         data = self.coordinator.data
         if not data:
             return 0
         filter_status = data.get("filter_status", [])
         if not isinstance(filter_status, list):
             return 0
+        radio_rooms = radiographic_rooms(filter_status)
         return sum(
             1 for device in filter_status
-            if isinstance(device, dict) and device.get("room") == room_code
+            if isinstance(device, dict)
+            and device.get("room") == room_code
+            and not is_superseded_meter(device, radio_rooms)
         )
 
     @property

--- a/custom_components/mijnted/sensors/device.py
+++ b/custom_components/mijnted/sensors/device.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from .base import MijnTedSensor, unit_slug
+from .base import MijnTedSensor, device_class_for, unit_slug
 from ..const import DOMAIN, UNIT_MIJNTED
 from ..utils import TranslationUtil
 
@@ -41,8 +41,14 @@ class MijnTedDeviceSensor(MijnTedSensor):
             label=label,
         )
         self.device_number = device_number
-        self._attr_icon = "mdi:radiator"
         self._attr_suggested_display_precision = 0
+
+    @property
+    def icon(self) -> str:
+        """Return an icon matching the meter type (water vs. heating)."""
+        if device_class_for(getattr(self, "meter_unit", None)) is not None:
+            return "mdi:water"
+        return "mdi:radiator"
 
     @property
     def _device_data(self) -> Optional[Dict[str, Any]]:
@@ -88,8 +94,25 @@ class MijnTedDeviceSensor(MijnTedSensor):
             room_code = device_data['room']
             hass = getattr(self.coordinator, 'hass', None)
             room_name = TranslationUtil.translate_room_code(room_code, hass)
+            # Disambiguate when a room contains more than one meter so they don't
+            # share an identical display name.
+            if self._room_meter_count(room_code) > 1:
+                return f"{label_prefix}device {room_name} {self.device_number}"
             return f"{label_prefix}device {room_name}"
         return f"{label_prefix}device {self.device_number}"
+
+    def _room_meter_count(self, room_code: Any) -> int:
+        """Count how many meters in filter_status share the given room code."""
+        data = self.coordinator.data
+        if not data:
+            return 0
+        filter_status = data.get("filter_status", [])
+        if not isinstance(filter_status, list):
+            return 0
+        return sum(
+            1 for device in filter_status
+            if isinstance(device, dict) and device.get("room") == room_code
+        )
 
     @property
     def state(self) -> Any:

--- a/custom_components/mijnted/sensors/diagnostics.py
+++ b/custom_components/mijnted/sensors/diagnostics.py
@@ -117,6 +117,26 @@ class MijnTedDeliveryTypesSensor(MijnTedSensor):
             return None
         return ", ".join(str(dt) for dt in delivery_types)
 
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Return discovered delivery-type detail.
+
+        Exposes each delivery type's id, active model code, friendly label, and
+        available units so all meters (heating, warm water, cold water) are
+        visible before per-type sensor sets are built (issue #50).
+
+        Returns:
+            Dictionary with a "delivery_types" list of per-type detail dicts.
+        """
+        data = self.coordinator.data
+        if not data:
+            return {}
+
+        detail = data.get("delivery_types_detail")
+        if isinstance(detail, list) and detail:
+            return {"delivery_types": detail}
+        return {}
+
 
 class MijnTedResidentialUnitDetailSensor(MijnTedSensor):
     """Sensor for residential unit details.

--- a/custom_components/mijnted/sensors/usage.py
+++ b/custom_components/mijnted/sensors/usage.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.components.recorder.models import StatisticData, StatisticMeanType
-from .base import MijnTedSensor, native_unit_for
+from .base import MijnTedSensor, display_precision_for, native_unit_for
 from ..utils import DataUtil
 from ..const import DEFAULT_START_VALUE
 from .models import CurrentData
@@ -25,7 +25,7 @@ class MijnTedMonthlyUsageSensor(MijnTedSensor):
         """
         super().__init__(coordinator, "monthly_usage", "monthly usage")
         self._attr_icon = "mdi:lightning-bolt"
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = display_precision_for(self.meter_unit)
 
     @property
     def state(self) -> Optional[float]:
@@ -130,7 +130,7 @@ class MijnTedLastYearMonthlyUsageSensor(MijnTedSensor):
         """
         super().__init__(coordinator, "last_year_monthly_usage", "last year monthly usage")
         self._attr_icon = "mdi:lightning-bolt"
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = display_precision_for(self.meter_unit)
 
     @property
     def state(self) -> Optional[float]:
@@ -200,7 +200,7 @@ class MijnTedAverageMonthlyUsageSensor(MijnTedSensor):
         """
         super().__init__(coordinator, "average_monthly_usage", "average monthly usage")
         self._attr_icon = "mdi:chart-line"
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = display_precision_for(self.meter_unit)
 
     @property
     def state(self) -> Optional[float]:
@@ -281,7 +281,7 @@ class MijnTedLastYearAverageMonthlyUsageSensor(MijnTedSensor):
         """
         super().__init__(coordinator, "last_year_average_monthly_usage", "last year average monthly usage")
         self._attr_icon = "mdi:chart-line-variant"
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = display_precision_for(self.meter_unit)
 
     @property
     def state(self) -> Optional[float]:
@@ -352,7 +352,7 @@ class MijnTedTotalUsageSensor(MijnTedSensor):
         super().__init__(coordinator, "total_usage", "total usage")
         self._attr_icon = "mdi:lightning-bolt"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_suggested_display_precision = 0
+        self._attr_suggested_display_precision = display_precision_for(self.meter_unit)
 
     @property
     def state(self) -> Optional[float]:

--- a/custom_components/mijnted/sensors/usage.py
+++ b/custom_components/mijnted/sensors/usage.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List, Optional
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.components.recorder.models import StatisticData, StatisticMeanType
-from .base import MijnTedSensor
+from .base import MijnTedSensor, native_unit_for
 from ..utils import DataUtil
-from ..const import UNIT_MIJNTED, DEFAULT_START_VALUE
+from ..const import DEFAULT_START_VALUE
 from .models import CurrentData
 
 
@@ -71,7 +71,7 @@ class MijnTedMonthlyUsageSensor(MijnTedSensor):
         Returns:
             Unit string constant
         """
-        return UNIT_MIJNTED
+        return native_unit_for(getattr(self, "meter_unit", None))
     
     @property
     def state_class(self) -> SensorStateClass:
@@ -157,7 +157,7 @@ class MijnTedLastYearMonthlyUsageSensor(MijnTedSensor):
         Returns:
             Unit string constant
         """
-        return UNIT_MIJNTED
+        return native_unit_for(getattr(self, "meter_unit", None))
     
     @property
     def state_class(self) -> SensorStateClass:
@@ -230,7 +230,7 @@ class MijnTedAverageMonthlyUsageSensor(MijnTedSensor):
         Returns:
             Unit string constant
         """
-        return UNIT_MIJNTED
+        return native_unit_for(getattr(self, "meter_unit", None))
     
     @property
     def state_class(self) -> SensorStateClass:
@@ -308,7 +308,7 @@ class MijnTedLastYearAverageMonthlyUsageSensor(MijnTedSensor):
         Returns:
             Unit string constant
         """
-        return UNIT_MIJNTED
+        return native_unit_for(getattr(self, "meter_unit", None))
     
     @property
     def state_class(self) -> SensorStateClass:
@@ -380,7 +380,7 @@ class MijnTedTotalUsageSensor(MijnTedSensor):
         Returns:
             Unit string constant
         """
-        return UNIT_MIJNTED
+        return native_unit_for(getattr(self, "meter_unit", None))
     
     def _collect_total_usage_entries(self, history: List[Any]) -> List[Dict[str, Any]]:
         """Collect and validate history entries for total usage statistics injection."""

--- a/custom_components/mijnted/translations/en.json
+++ b/custom_components/mijnted/translations/en.json
@@ -9,7 +9,7 @@
           "client_id": "MijnTed account client-id",
           "polling_interval": "Polling interval (seconds)"
         },
-        "description": "How often to poll the API for updates. Default: 3600 seconds (1 hour). Range: 900-86400 seconds (15 minutes to 24 hours)."
+        "description": "How often to poll the API for updates. Default: 3600 seconds (1 hour). Range: 3600-86400 seconds (1 hour to 24 hours)."
       },
       "reauth_confirm": {
         "title": "Reauthenticate with your MijnTed credentials",
@@ -19,7 +19,7 @@
           "client_id": "MijnTed account client-id",
           "polling_interval": "Polling interval (seconds)"
         },
-        "description": "How often to poll the API for updates. Default: 3600 seconds (1 hour). Range: 900-86400 seconds (15 minutes to 24 hours)."
+        "description": "How often to poll the API for updates. Default: 3600 seconds (1 hour). Range: 3600-86400 seconds (1 hour to 24 hours)."
       }
     },
     "error": {

--- a/doc/ENDPOINTS.md
+++ b/doc/ENDPOINTS.md
@@ -46,6 +46,18 @@ All data endpoints require authentication via Bearer token in the `Authorization
 - `Authorization: Bearer {access_token}`
 - `User-Agent: HomeAssistant/MijnTed`
 
+### Delivery-type discovery and the `unitOfMeasure` query parameter
+
+The integration supports multiple delivery types (meters) per residential unit. Discovery runs in three steps:
+
+1. `GET /api/address/deliveryTypes/{residential_unit}` lists the available delivery types (e.g. `[1, 2, 3]`).
+2. `GET /api/activeModel/{residential_unit}/{delivery_type}` returns the model code per type, which determines the friendly label (Heating / Warm water / Cold water).
+3. `GET /api/unitOfMeasures/{residential_unit}/{delivery_type}/{year}` returns the available units for that type.
+
+For each discovered `(delivery_type, unit)` combination, the per-type data endpoints below are called with the matching `delivery_type` in the path.
+
+**`?unitOfMeasure=GJ` rule**: The optional `unitOfMeasure` query parameter is appended **only for heating (type 1) when the `GJ` unit is selected**. Water types (warm/cold) default to `m³` and omit the parameter; heating with the `Eenheden` unit also omits it. This applies to the usage, last-sync, device-status, usage-insight, and usage-per-room endpoints.
+
 ### Get Delivery Types
 **Endpoint**: `GET /api/address/deliveryTypes/{residential_unit}`
 
@@ -60,6 +72,13 @@ All data endpoints require authentication via Bearer token in the `Authorization
 ```
 
 **Example**: `GET /api/address/deliveryTypes/123456`
+
+**Notes**:
+- Each delivery type maps to a separate physical meter type. Known types:
+  - **1 = Heating** (`activeModel` `F59`/WMZ family). Available units: `eenheid` (`Eenheden`) and `GJ`.
+  - **2 = Warm water** (`activeModel` `WWZ`). Unit: `m³`.
+  - **3 = Cold water** (`activeModel` `KWZ`). Unit: `m³`.
+- The integration discovers all delivery types here and, for each one, fetches the active model (see [Get Active Model](#get-active-model)) and the available units (see [Get Unit of Measures](#get-unit-of-measures)) to build one Home Assistant device and sensor set per `(delivery_type, unit)` combination.
 
 ---
 
@@ -222,6 +241,9 @@ All data endpoints require authentication via Bearer token in the `Authorization
 
 **Example**: `GET /api/activeModel/123456/1`
 
+**Notes**:
+- Used during delivery-type discovery to derive a friendly label per type. Known model families: `F59`/WMZ → Heating, `WWZ` → Warm water, `KWZ` → Cold water.
+
 ---
 
 ### Get Residential Unit Detail
@@ -320,7 +342,8 @@ All data endpoints require authentication via Bearer token in the `Authorization
 **Notes**:
 - Returns an array of unit of measure objects
 - Each object contains a `value` (internal identifier) and `displayName` (human-readable name)
-- Typically returns a single item in the array
+- Used during discovery to enumerate the units available per delivery type. Heating (type 1) typically returns both `eenheid` (`Eenheden`) and `GJ`; water types return `m³`.
+- The integration creates one device/sensor set per `(delivery_type, unit)` combination returned here (subject to the Options-flow selection).
 
 ---
 

--- a/doc/SENSORS.md
+++ b/doc/SENSORS.md
@@ -23,6 +23,29 @@ This document describes all MijnTed sensors, what they represent, and how they b
 - Some sensors keep an in-memory `_last_known_value` and return that during partial outages.
 - `_last_known_value` is not persisted across Home Assistant restarts.
 
+## Multi-Meter Devices (Per Delivery Type / Unit)
+
+The MijnTed API exposes multiple **delivery types** (meters) per residential unit, discovered via `GET /api/address/deliveryTypes/{unit}` (see [ENDPOINTS.md](./ENDPOINTS.md)):
+
+- **Type 1 = Heating** (`activeModel` `F59`/WMZ), available units `Eenheden` and `GJ`
+- **Type 2 = Warm water** (`activeModel` `WWZ`), unit `m³`
+- **Type 3 = Cold water** (`activeModel` `KWZ`), unit `m³`
+
+The integration creates **one Home Assistant device plus a full sensor set per `(delivery_type, unit)` combination**. Each device carries the same sensor suite described below (monthly/total/average usage, last-year variants, per-device meter readings, diagnostics, and HA Energy dashboard statistics injection); only the meter and unit differ. For example, a home with all three meters and heating reported in both units yields four devices:
+
+- `MijnTed Heating (Eenheden)`
+- `MijnTed Heating (GJ)`
+- `MijnTed Warm water (m³)`
+- `MijnTed Cold water (m³)`
+
+Notes:
+
+- **Units** follow the meter: water sensors use `m³` with device class `water`; heating uses `GJ` or normalized `Units` (from `Eenheden`/`Einheiten`). The unit descriptions below were written for the original single (heating) meter and apply per meter, with the unit substituted accordingly.
+- **Unit selection**: which `(delivery_type, unit)` combinations are enabled is configurable via the integration's **Options flow** (default: all discovered combinations).
+- **`?unitOfMeasure=GJ`**: appended only for heating when the `GJ` unit is selected; water types default to `m³` and omit it.
+- **Transient empty water data**: the MijnTed water page intermittently returns "no meters"/empty data until refreshed. The integration tolerates transient empty responses and keeps last-known data per meter.
+- The sensor unique IDs and device sensors below are scoped per device, so identical sensor types coexist across meters without collision.
+
 ## Sensor Catalog
 
 ## Usage Sensors

--- a/tests/fixtures/api_multi_delivery.json
+++ b/tests/fixtures/api_multi_delivery.json
@@ -1,0 +1,528 @@
+{
+  "/api/address/deliveryTypes/100000": [
+    1,
+    2,
+    3
+  ],
+  "/api/activeModel/100000/1": "F59",
+  "/api/activeModel/100000/2": "WWZ",
+  "/api/activeModel/100000/3": "KWZ",
+  "/api/deviceStatuses/100000/1/2026?fromDate=2026-06-20": [
+    {
+      "measurementDeviceId": 900000,
+      "room": "W",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 0.0,
+      "unitOfMeasure": "Einheiten",
+      "deactivationDate": "02-02-2026 00:00:00",
+      "radiographicMeter": true
+    },
+    {
+      "measurementDeviceId": 900000,
+      "room": "KA",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 0.0,
+      "unitOfMeasure": "Einheiten",
+      "deactivationDate": "02-02-2026 00:00:00",
+      "radiographicMeter": true
+    },
+    {
+      "measurementDeviceId": 900000,
+      "room": "KEU",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 0.0,
+      "unitOfMeasure": "Einheiten",
+      "deactivationDate": "02-02-2026 00:00:00",
+      "radiographicMeter": true
+    },
+    {
+      "measurementDeviceId": 900000,
+      "room": "KEU",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 0.0,
+      "unitOfMeasure": "Einheiten",
+      "deactivationDate": "02-02-2026 00:00:00",
+      "radiographicMeter": true
+    }
+  ],
+  "/api/unitOfMeasures/100000/1/2026": [
+    {
+      "value": "eenheid",
+      "displayName": "Eenheden"
+    },
+    {
+      "value": "GJ",
+      "displayName": "GJ"
+    }
+  ],
+  "/api/deviceStatuses/100000/1/2026?unitOfMeasure=GJ&fromDate=2026-06-20": [
+    {
+      "measurementDeviceId": 900000,
+      "room": "ALG",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 0.627,
+      "unitOfMeasure": "GJ",
+      "deactivationDate": "",
+      "radiographicMeter": true
+    },
+    {
+      "measurementDeviceId": 900000,
+      "room": "ALG",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 1.887,
+      "unitOfMeasure": "GJ",
+      "deactivationDate": "",
+      "radiographicMeter": true
+    }
+  ],
+  "/api/getLastSyncDate/100000/2/2026": "19/06/2026",
+  "/api/deviceStatuses/100000/2/2026?unitOfMeasure=GJ&fromDate=2026-06-20": [],
+  "/api/residentialUnitUsage/2026/100000/2?unitOfMeasure=GJ": {
+    "monthlyEnergyUsages": [
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "12.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "11.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "10.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "9.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "8.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "7.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "6.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "5.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "4.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "3.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "2.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "1.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      }
+    ],
+    "averageEnergyUseForBillingUnit": 0
+  },
+  "/api/unitOfMeasures/100000/2/2026": [
+    {
+      "value": "m³",
+      "displayName": "m³"
+    }
+  ],
+  "/api/deviceStatuses/100000/3/2026?unitOfMeasure=GJ&fromDate=2026-06-20": [],
+  "/api/residentialUnitUsage/2026/100000/3?unitOfMeasure=GJ": {
+    "monthlyEnergyUsages": [
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "12.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "11.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "10.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "9.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "8.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "7.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "6.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "5.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "4.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "3.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "2.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "1.2026",
+        "unitOfMeasurement": "Eenheden",
+        "averageEnergyUseForBillingUnit": null
+      }
+    ],
+    "averageEnergyUseForBillingUnit": 0
+  },
+  "/api/unitOfMeasures/100000/3/2026": [
+    {
+      "value": "m³",
+      "displayName": "m³"
+    }
+  ],
+  "/api/deviceStatuses/100000/3/2026?fromDate=2026-06-20": [
+    {
+      "measurementDeviceId": 900000,
+      "room": "ALG",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 0.0,
+      "unitOfMeasure": "m³",
+      "deactivationDate": "",
+      "radiographicMeter": false
+    },
+    {
+      "measurementDeviceId": 900000,
+      "room": "ALG",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 8.051,
+      "unitOfMeasure": "m³",
+      "deactivationDate": "",
+      "radiographicMeter": true
+    }
+  ],
+  "/api/residentialUnitUsage/2026/100000/3": {
+    "monthlyEnergyUsages": [
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "1.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "2.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 5.5,
+        "monthYear": "3.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": 1.82
+      },
+      {
+        "totalEnergyUsage": 1.21,
+        "monthYear": "4.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": 1.67
+      },
+      {
+        "totalEnergyUsage": 0.91,
+        "monthYear": "5.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": 1.92
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "6.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "7.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "8.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "9.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "10.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "11.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "12.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      }
+    ],
+    "averageEnergyUseForBillingUnit": 0
+  },
+  "/api/deviceStatuses/100000/2/2026?fromDate=2026-06-20": [
+    {
+      "measurementDeviceId": 900000,
+      "room": "ALG",
+      "deviceId": 900000,
+      "deviceNumber": "",
+      "currentReadingValue": 0.0,
+      "unitOfMeasure": "m³",
+      "deactivationDate": "",
+      "radiographicMeter": false
+    },
+    {
+      "measurementDeviceId": 900000,
+      "room": "ALG",
+      "deviceId": 900000,
+      "deviceNumber": "000000",
+      "currentReadingValue": 30.918,
+      "unitOfMeasure": "m³",
+      "deactivationDate": "",
+      "radiographicMeter": true
+    }
+  ],
+  "/api/residentialUnitUsage/2026/100000/2": {
+    "monthlyEnergyUsages": [
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "1.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "2.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 18.03,
+        "monthYear": "3.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": 1.76
+      },
+      {
+        "totalEnergyUsage": 5.56,
+        "monthYear": "4.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": 0.97
+      },
+      {
+        "totalEnergyUsage": 4.62,
+        "monthYear": "5.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": 0.94
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "6.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "7.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "8.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "9.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "10.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "11.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "12.2026",
+        "unitOfMeasurement": "m³",
+        "averageEnergyUseForBillingUnit": null
+      }
+    ],
+    "averageEnergyUseForBillingUnit": 0
+  },
+  "/api/residentialUnitUsage/2026/100000/1?unitOfMeasure=GJ": {
+    "monthlyEnergyUsages": [
+      {
+        "totalEnergyUsage": 1.55,
+        "monthYear": "1.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": 2.7
+      },
+      {
+        "totalEnergyUsage": 0.67,
+        "monthYear": "2.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": 1.3
+      },
+      {
+        "totalEnergyUsage": 0.25,
+        "monthYear": "3.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": 0.64
+      },
+      {
+        "totalEnergyUsage": 0.04,
+        "monthYear": "4.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": 0.27
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "5.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": 0.09
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "6.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "7.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "8.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "9.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "10.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "11.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      },
+      {
+        "totalEnergyUsage": 0.0,
+        "monthYear": "12.2026",
+        "unitOfMeasurement": "GJ",
+        "averageEnergyUseForBillingUnit": null
+      }
+    ],
+    "averageEnergyUseForBillingUnit": 0
+  }
+}

--- a/tests/test_delivery_discovery.py
+++ b/tests/test_delivery_discovery.py
@@ -1,0 +1,88 @@
+"""Tests for multi-delivery-type discovery (issue #50).
+
+Exercises the API discovery helpers against scrubbed real responses captured
+from the MijnTed API (``tests/fixtures/api_multi_delivery.json``).
+"""
+import json
+import pathlib
+
+import pytest
+
+from custom_components.mijnted.api import MijntedApi
+
+_FIXTURES = json.loads(
+    (pathlib.Path(__file__).parent / "fixtures" / "api_multi_delivery.json").read_text()
+)
+
+
+def _make_api(monkeypatch):
+    """Build a MijntedApi whose _make_request is served from fixtures."""
+    api = MijntedApi(hass=object(), client_id="test-client", residential_unit="100000")
+
+    async def fake_make_request(method, url, **kwargs):
+        for path, body in _FIXTURES.items():
+            if url.endswith(path):
+                return body
+        raise AssertionError(f"No fixture for {url}")
+
+    monkeypatch.setattr(api, "_make_request", fake_make_request)
+    monkeypatch.setattr(MijntedApi, "_get_current_year", staticmethod(lambda: 2026))
+    return api
+
+
+class TestUnitQueryParams:
+    def test_gj_appends_param(self):
+        assert MijntedApi.unit_query_params("GJ") == {"unitOfMeasure": "GJ"}
+
+    def test_gj_case_insensitive(self):
+        assert MijntedApi.unit_query_params("gj") == {"unitOfMeasure": "GJ"}
+
+    @pytest.mark.parametrize("unit", ["m³", "eenheid", "Eenheden", "", None])
+    def test_non_gj_omits_param(self, unit):
+        assert MijntedApi.unit_query_params(unit) is None
+
+
+class TestDeliveryTypeLabel:
+    @pytest.mark.parametrize(
+        "model,label",
+        [
+            ("F59", "Heating"),
+            ("WWZ", "Warm water"),
+            ("KWZ", "Cold water"),
+            ("wwz", "Warm water"),
+        ],
+    )
+    def test_known_models(self, model, label):
+        assert MijntedApi._delivery_type_label(model) == label
+
+    def test_unknown_model_passes_through(self):
+        assert MijntedApi._delivery_type_label("XYZ") == "XYZ"
+
+    def test_none_returns_none(self):
+        assert MijntedApi._delivery_type_label(None) is None
+
+
+class TestDiscoverDeliveryTypes:
+    @pytest.mark.asyncio
+    async def test_discovers_all_three_types(self, monkeypatch):
+        api = _make_api(monkeypatch)
+
+        discovered = await api.discover_delivery_types()
+
+        assert [d["id"] for d in discovered] == [1, 2, 3]
+        by_id = {d["id"]: d for d in discovered}
+        assert by_id[1]["model"] == "F59"
+        assert by_id[1]["label"] == "Heating"
+        assert by_id[2]["label"] == "Warm water"
+        assert by_id[3]["label"] == "Cold water"
+
+    @pytest.mark.asyncio
+    async def test_units_per_type(self, monkeypatch):
+        api = _make_api(monkeypatch)
+
+        by_id = {d["id"]: d for d in await api.discover_delivery_types()}
+
+        heating_units = {u["value"] for u in by_id[1]["units"]}
+        assert heating_units == {"eenheid", "GJ"}
+        assert [u["value"] for u in by_id[2]["units"]] == ["m³"]
+        assert [u["value"] for u in by_id[3]["units"]] == ["m³"]

--- a/tests/test_multi_meter.py
+++ b/tests/test_multi_meter.py
@@ -92,6 +92,22 @@ class TestApiUnitThreading:
         assert api.delivery_type == 2
 
 
+class TestSupersededMeter:
+    def test_old_non_radio_in_radio_room_is_superseded(self):
+        fs = [
+            {"room": "ALG", "deviceNumber": "0465748", "radiographicMeter": False},
+            {"room": "ALG", "deviceNumber": "86066883", "radiographicMeter": True},
+        ]
+        rooms = base.radiographic_rooms(fs)
+        assert base.is_superseded_meter(fs[0], rooms) is True
+        assert base.is_superseded_meter(fs[1], rooms) is False
+
+    def test_standalone_non_radio_is_kept(self):
+        fs = [{"room": "KEU", "deviceNumber": "1", "radiographicMeter": False}]
+        rooms = base.radiographic_rooms(fs)
+        assert base.is_superseded_meter(fs[0], rooms) is False
+
+
 class TestBaseUniqueIdNamespacing:
     def test_namespaced_unique_id(self):
         assert base.MijnTedSensor._namespaced_unique_id(

--- a/tests/test_multi_meter.py
+++ b/tests/test_multi_meter.py
@@ -1,0 +1,110 @@
+"""Tests for multi-delivery-type meter wiring (issue #50, step 2)."""
+import pytest
+
+from custom_components.mijnted import (
+    MeterContext,
+    _meters_from_detail,
+)
+from custom_components.mijnted.api import MijntedApi
+from custom_components.mijnted.sensors import base
+
+
+_DETAIL = [
+    {"id": 1, "model": "F59", "label": "Heating",
+     "units": [{"value": "eenheid", "displayName": "Eenheden"}, {"value": "GJ", "displayName": "GJ"}]},
+    {"id": 2, "model": "WWZ", "label": "Warm water", "units": [{"value": "m³", "displayName": "m³"}]},
+    {"id": 3, "model": "KWZ", "label": "Cold water", "units": [{"value": "m³", "displayName": "m³"}]},
+]
+
+
+class TestUnitSlug:
+    @pytest.mark.parametrize("unit,slug", [
+        ("m³", "m3"), ("GJ", "gj"), ("eenheid", "eenheid"), ("Eenheden", "eenheden"),
+        (None, "default"), ("", "default"),
+    ])
+    def test_slug(self, unit, slug):
+        assert base.unit_slug(unit) == slug
+
+
+class TestUnitMapping:
+    def test_water_maps_to_volume_and_device_class(self):
+        assert base.native_unit_for("m³") is base.UnitOfVolume.CUBIC_METERS
+        assert base.device_class_for("m³") is base.SensorDeviceClass.WATER
+
+    def test_gj_passthrough(self):
+        assert base.native_unit_for("GJ") == "GJ"
+        assert base.device_class_for("GJ") is None
+
+    def test_default_is_units(self):
+        assert base.native_unit_for(None) == base.UNIT_MIJNTED
+        assert base.device_class_for("eenheid") is None
+
+
+class TestMeterContext:
+    def test_key_and_cache_id(self):
+        meter = MeterContext(delivery_type=2, unit="m³", label="Warm water")
+        assert meter.key == "2_m3"
+        assert meter.cache_id("abc") == "abc_2_m3"
+
+    def test_unit_slug_property(self):
+        assert MeterContext(1, "GJ", "Heating").unit_slug == "gj"
+
+
+class TestMetersFromDetail:
+    def test_all_meters(self):
+        meters = _meters_from_detail(_DETAIL)
+        assert [m.key for m in meters] == ["1_eenheid", "1_gj", "2_m3", "3_m3"]
+        assert meters[0].label == "Heating"
+        assert meters[2].label == "Warm water"
+
+    def test_enabled_filter(self):
+        meters = _meters_from_detail(_DETAIL, enabled_keys={"2_m3", "3_m3"})
+        assert [m.key for m in meters] == ["2_m3", "3_m3"]
+
+    def test_type_without_units_gets_default(self):
+        meters = _meters_from_detail([{"id": 9, "label": "X", "units": []}])
+        assert [m.key for m in meters] == ["9_default"]
+
+
+class TestApiUnitThreading:
+    def test_gj_unit_appends_param(self):
+        api = MijntedApi(hass=object(), client_id="c", residential_unit="1", unit="GJ")
+        assert api._with_unit("http://x/api/foo/1/1") == "http://x/api/foo/1/1?unitOfMeasure=GJ"
+
+    def test_gj_preserves_existing_query(self):
+        api = MijntedApi(hass=object(), client_id="c", residential_unit="1", unit="GJ")
+        out = api._with_unit("http://x/api/foo?fromDate=2026-01-01")
+        assert out == "http://x/api/foo?fromDate=2026-01-01&unitOfMeasure=GJ"
+
+    def test_water_unit_no_param(self):
+        api = MijntedApi(hass=object(), client_id="c", residential_unit="1", unit="m³")
+        assert api._with_unit("http://x/api/foo") == "http://x/api/foo"
+
+    @pytest.mark.asyncio
+    async def test_pinned_delivery_type_not_overwritten(self, monkeypatch):
+        api = MijntedApi(hass=object(), client_id="c", residential_unit="1", delivery_type=2)
+
+        async def fake(method, url, **kwargs):
+            return [1, 2, 3]
+
+        monkeypatch.setattr(api, "_make_request", fake)
+        await api.get_delivery_types()
+        assert api.delivery_type == 2
+
+
+class TestBaseUniqueIdNamespacing:
+    def test_namespaced_unique_id(self):
+        assert base.MijnTedSensor._namespaced_unique_id(
+            "monthly_usage", delivery_type=2, unit="m³"
+        ) == "mijnted_2_m3_monthly_usage"
+
+    def test_legacy_unique_id_when_no_delivery_type(self):
+        assert base.MijnTedSensor._namespaced_unique_id(
+            "monthly_usage"
+        ) == "mijnted_monthly_usage"
+
+    def test_name_uses_label(self):
+        sensor = object.__new__(base.MijnTedSensor)
+        sensor._name = "monthly usage"
+        sensor.meter_label = "Warm water"
+        assert sensor.name == "MijnTed Warm water monthly usage"

--- a/tests/test_statistics_reinject.py
+++ b/tests/test_statistics_reinject.py
@@ -86,7 +86,11 @@ class TestEnsureMonthlyHistoryCacheStatisticsReinject:
         hass = MagicMock()
         hass.data = {
             init_mod.DOMAIN: {
-                entry.entry_id: existing_coordinator,
+                entry.entry_id: {
+                    "coordinators": {"": existing_coordinator},
+                    "meters": [],
+                    "discovery": [],
+                },
             }
         }
         cache = {"2026-02": _make_cache_entry(2, 2026, total_usage=245.0, average_usage=10.0)}


### PR DESCRIPTION
## Multi-delivery-type sensor support (Fixes #50)

Implements simultaneous support for all MijnTed delivery types — heating, warm water, and cold water — each with its own Home Assistant device and full sensor set, instead of only the first delivery type.

### What changed

**Discovery**
- `api.discover_delivery_types()` lists every delivery type and, per type, its active model and available units (`unitOfMeasures`).
- The `?unitOfMeasure=GJ` query parameter is now applied **only** for heating when the GJ unit is selected; water types default to `m³` and omit it.

**Per-meter architecture**
- One `DataUpdateCoordinator` + one HA device + one full sensor set per `(delivery_type, unit)` pair, reusing the existing single-type pipeline parameterized by delivery type and unit. Per-meter persistent storage keys.
- A home with all three meters (heating in both Eenheden and GJ) yields four devices: `MijnTed Heating (Eenheden)`, `MijnTed Heating (GJ)`, `MijnTed Warm water (m³)`, `MijnTed Cold water (m³)`.
- Sensor `unique_id`s, devices, and names are namespaced per meter; units map to the right HA native unit and device class (`m³` → `water`); statistics are injected per meter for the Energy dashboard.

**Migration & robustness**
- One-time `unique_id` + device migration moves pre-existing single-type entities onto the primary meter so recorder history / long-term statistics survive the uniform rename; the now-empty legacy device is removed.
- The primary meter gates entry setup (a fully-down account still retries) while additional meters refresh non-fatally — the MijnTed water page intermittently returns empty data, so one flaky meter won't block the others.
- Decommissioned non-radiographic meters replaced by a radiographic meter in the same room are hidden.

**Options flow**
- New multi-select to choose which discovered `(delivery_type, unit)` meters to expose (default: all), data-driven from discovery since available units vary per home.

**Misc**
- Fix polling-interval help text to match the enforced 1-hour minimum.
- Docs updated (`SENSORS.md`, `ENDPOINTS.md`, `README.md`).

### Testing
- 263 tests pass, including new coverage for discovery, meter/slug/unit mapping, the GJ-parameter rule, namespacing, and the superseded-meter filter.
- Fixtures derived from real (anonymized) API responses across all three delivery types.
- Verified live on a unit with heating + warm + cold water.

### Note for the maintainer
This PR intentionally **does not** include the #46 statistics fixes or the `has_entity_name` change from #47, to avoid overlapping that open PR. The multi-meter naming here would conflict with `has_entity_name`; happy to rebase on top of #47 in whichever order you prefer to merge.
